### PR TITLE
DBZ-5937 - Fixes to the Spanner connector

### DIFF
--- a/src/main/java/io/debezium/connector/spanner/FinishPartitionWatchDog.java
+++ b/src/main/java/io/debezium/connector/spanner/FinishPartitionWatchDog.java
@@ -60,6 +60,7 @@ public class FinishPartitionWatchDog {
             }
 
         }, "SpannerConnector-FinishingPartitionWatchDog");
+        this.thread.start();
     }
 
     public void stop() {

--- a/src/main/java/io/debezium/connector/spanner/FinishPartitionWatchDog.java
+++ b/src/main/java/io/debezium/connector/spanner/FinishPartitionWatchDog.java
@@ -39,7 +39,9 @@ public class FinishPartitionWatchDog {
                 List<String> tokens = new ArrayList<>();
 
                 partition.forEach((token, instant) -> {
-                    if (instant.isAfter(instant.plus(timeout))) {
+                    Instant now = Instant.now();
+                    LOGGER.info("Partitions awaiting finish: {}", tokens);
+                    if (now.isAfter(instant.plus(timeout))) {
                         tokens.add(token);
                     }
                 });

--- a/src/main/java/io/debezium/connector/spanner/SpannerStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/spanner/SpannerStreamingChangeEventSource.java
@@ -48,7 +48,7 @@ public class SpannerStreamingChangeEventSource implements CommittingRecordsStrea
 
     private static final StuckPartitionStrategy STUCK_PARTITION_STRATEGY = StuckPartitionStrategy.ESCALATE;
 
-    private static final Duration FINISHING_PARTITION_TIMEOUT = Duration.ofSeconds(60);
+    private static final Duration FINISHING_PARTITION_TIMEOUT = Duration.ofSeconds(300);
 
     private final FinishPartitionStrategy finishPartitionStrategy;
 
@@ -290,6 +290,7 @@ public class SpannerStreamingChangeEventSource implements CommittingRecordsStrea
                 continue;
             }
 
+            LOGGER.debug("Committing record {} in StreamingChangeEventSource for token {}", recordUid, token);
             this.finishingPartitionManager.commitRecord(token, recordUid);
         }
     }


### PR DESCRIPTION
Instead of checking that the last emitted record id is equal to the last committed record id, check that all emitted records were committed before updating a partition status to be FINISHED, in case records are committed out of order.


If a partition has been pending finish for a long time, make sure to throw an exception.