### PR TITLE
Fix duplicate columns error

### DIFF
--- a/src/main/java/io/debezium/connector/spanner/db/model/schema/SpannerSchema.java
+++ b/src/main/java/io/debezium/connector/spanner/db/model/schema/SpannerSchema.java
@@ -51,7 +51,9 @@ public class SpannerSchema {
                 columns = new ArrayList<>();
                 tableMap.put(tableName, columns);
             }
-            columns.add(Column.create(columnName, type, primaryKey, ordinalPosition, nullable));
+            if (!columns.stream().anyMatch(column -> column.getName().equals(columnName))) {
+                columns.add(Column.create(columnName, type, primaryKey, ordinalPosition, nullable));
+            }
         }
 
         public SpannerSchema build() {


### PR DESCRIPTION
Currently when there are multiple indexes on the same column in spanner table then debezium connector is not able to start throwing error. For ex
`Task failure, taskUid: livestream-connector_task-0_070f2388-117e-4271-a7b2-6ec30b208681, java.lang.IllegalStateException: Duplicate key host_id (attempted merging values io.debezium.connector.spanner.db.model.schema.Column@21611983 and io.debezium.connector.spanner.db.model.schema.Column@176fc767)`

So added a filter on stream before calling Collectors.toMap because of which this issue is occuring. 

This code return duplicate columns when there are multiple indexes on same column. https://github.com/debezium/debezium-connector-spanner/blob/8cb85d7aaa3c1edf33c18b257a33902f37ea47d9/src/main/java/io/debezium/connector/spanner/db/dao/SchemaDao.java#L80 Leading to the error.