### PR TITLE
DBZ-6228 Add support for configuring max.message.bytes of sync topic.

### DIFF
--- a/src/main/java/io/debezium/connector/spanner/SpannerConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/spanner/SpannerConnectorConfig.java
@@ -294,4 +294,8 @@ public class SpannerConnectorConfig extends BaseSpannerConnectorConfig {
     public int getTopicNumPartitions() {
         return getConfig().getInteger(TOPIC_DEFAULT_AUTO_CREATION_PARTITIONS_FIELD);
     }
+
+    public String syncTopicMaxMessageSize() {
+        return getConfig().getString(SYNC_TOPIC_MAX_MESSAGE_BYTES);
+    }
 }

--- a/src/main/java/io/debezium/connector/spanner/config/BaseSpannerConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/spanner/config/BaseSpannerConnectorConfig.java
@@ -97,6 +97,8 @@ public abstract class BaseSpannerConnectorConfig extends CommonConnectorConfig {
     private static final String TASKS_FAIL_OVERLOADED_PROPERTY_NAME = "tasks.fail.overloaded";
     private static final String TASKS_FAIL_OVERLOADED_CHECK_INTERVAL_PROPERTY_NAME = "tasks.fail.overloaded.check.interval";
 
+    private static final String CONNECTOR_SPANNER_SYNC_TOPIC_MAX_MESSAGE_BYTES_PROPERTY_NAME = "connector.spanner.sync.max.message.bytes";
+
     protected static final Field LOW_WATERMARK_ENABLED_FIELD = Field.create(LOW_WATERMARK_ENABLED)
             .withDisplayName(LOW_WATERMARK_ENABLED)
             .withType(Type.BOOLEAN)
@@ -526,6 +528,15 @@ public abstract class BaseSpannerConnectorConfig extends CommonConnectorConfig {
             .withImportance(Importance.LOW)
             .withDefault(10000)
             .withDescription("Percentage metrics clear interval");
+
+    protected static final Field SYNC_TOPIC_MAX_MESSAGE_BYTES = Field.create(CONNECTOR_SPANNER_SYNC_TOPIC_MAX_MESSAGE_BYTES_PROPERTY_NAME)
+            .withDisplayName("Sync topic max message size")
+            .withType(Type.STRING)
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR, 18))
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.HIGH)
+            .withDefault("10485880")
+            .withDescription("Sync topic max message size");
 
     protected static final ConfigDefinition CONFIG_DEFINITION = ConfigDefinition.editor()
             .name("Spanner")

--- a/src/main/java/io/debezium/connector/spanner/config/BaseSpannerConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/spanner/config/BaseSpannerConnectorConfig.java
@@ -532,7 +532,7 @@ public abstract class BaseSpannerConnectorConfig extends CommonConnectorConfig {
     protected static final Field SYNC_TOPIC_MAX_MESSAGE_BYTES = Field.create(CONNECTOR_SPANNER_SYNC_TOPIC_MAX_MESSAGE_BYTES_PROPERTY_NAME)
             .withDisplayName("Sync topic max message size")
             .withType(Type.STRING)
-            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR, 18))
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR, 19))
             .withWidth(Width.SHORT)
             .withImportance(Importance.HIGH)
             .withDefault("10485880")

--- a/src/main/java/io/debezium/connector/spanner/kafka/internal/KafkaInternalTopicAdminService.java
+++ b/src/main/java/io/debezium/connector/spanner/kafka/internal/KafkaInternalTopicAdminService.java
@@ -62,6 +62,7 @@ public class KafkaInternalTopicAdminService {
                 topicProps.put(TopicConfig.RETENTION_MS_CONFIG, String.valueOf(config.syncRetentionMs()));
                 topicProps.put(TopicConfig.SEGMENT_MS_CONFIG, String.valueOf(config.syncSegmentMs()));
                 topicProps.put(TopicConfig.MIN_CLEANABLE_DIRTY_RATIO_CONFIG, config.syncMinCleanableDirtyRatio());
+                topicProps.put(TopicConfig.MAX_MESSAGE_BYTES_CONFIG, config.syncTopicMaxMessageSize());
 
                 createTopic(syncTopic, Optional.of(1), topicProps);
                 return;


### PR DESCRIPTION
Keeping default to 10MB.