### PR TITLE
DBZ-6227 Reduce CPU usage and ensure critical logs have task Uid

### DIFF
--- a/src/main/java/io/debezium/connector/spanner/FinishPartitionWatchDog.java
+++ b/src/main/java/io/debezium/connector/spanner/FinishPartitionWatchDog.java
@@ -27,7 +27,7 @@ public class FinishPartitionWatchDog {
     private volatile Thread thread;
     private final Map<String, Instant> partition = new HashMap<>();
     private final Duration pollInterval = Duration.ofMillis(60000);
-    private final Duration sleepInterval = Duration.ofMillis(1000);
+    private final Duration sleepInterval = Duration.ofMillis(100);
     private final Clock clock;
 
     public FinishPartitionWatchDog(FinishingPartitionManager finishingPartitionManager, Duration timeout, Consumer<List<String>> errorHandler) {

--- a/src/main/java/io/debezium/connector/spanner/SpannerChangeEventSourceFactory.java
+++ b/src/main/java/io/debezium/connector/spanner/SpannerChangeEventSourceFactory.java
@@ -68,7 +68,7 @@ public class SpannerChangeEventSourceFactory implements ChangeEventSourceFactory
 
         SpannerOffsetContextFactory offsetContextFactory = new SpannerOffsetContextFactory(sourceInfoFactory);
 
-        return new SpannerStreamingChangeEventSource(errorHandler,
+        return new SpannerStreamingChangeEventSource(connectorConfig, errorHandler,
                 changeStream,
                 streamEventQueue,
                 spannerMeter.getMetricsEventPublisher(),

--- a/src/main/java/io/debezium/connector/spanner/SpannerConnectorTask.java
+++ b/src/main/java/io/debezium/connector/spanner/SpannerConnectorTask.java
@@ -136,6 +136,7 @@ public class SpannerConnectorTask extends SpannerBaseSourceTask {
                 event -> this.synchronizationTaskContext.publishEvent(event));
 
         final SpannerChangeStreamFactory spannerChangeStreamFactory = new SpannerChangeStreamFactory(
+                this.taskUid,
                 daoFactory,
                 spannerMeter.getMetricsEventPublisher(),
                 connectorConfig.getConnectorName(),

--- a/src/main/java/io/debezium/connector/spanner/SpannerStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/spanner/SpannerStreamingChangeEventSource.java
@@ -71,9 +71,12 @@ public class SpannerStreamingChangeEventSource implements CommittingRecordsStrea
 
     private final SpannerOffsetContextFactory offsetContextFactory;
 
+    private final SpannerConnectorConfig connectorConfig;
+
     private volatile Thread thread;
 
-    public SpannerStreamingChangeEventSource(ErrorHandler errorHandler,
+    public SpannerStreamingChangeEventSource(SpannerConnectorConfig connectorConfig,
+                                             ErrorHandler errorHandler,
                                              ChangeStream stream,
                                              StreamEventQueue eventQueue,
                                              MetricsEventPublisher metricsEventPublisher,
@@ -82,6 +85,7 @@ public class SpannerStreamingChangeEventSource implements CommittingRecordsStrea
                                              SpannerEventDispatcher spannerEventDispatcher,
                                              boolean finishingAfterCommit,
                                              SpannerOffsetContextFactory offsetContextFactory) {
+        this.connectorConfig = connectorConfig;
         this.offsetContextFactory = offsetContextFactory;
         this.errorHandler = errorHandler;
         this.eventQueue = eventQueue;
@@ -90,7 +94,7 @@ public class SpannerStreamingChangeEventSource implements CommittingRecordsStrea
         this.partitionManager = partitionManager;
         this.schemaRegistry = schemaRegistry;
         this.spannerEventDispatcher = spannerEventDispatcher;
-        this.finishingPartitionManager = new FinishingPartitionManager(partitionManager::updateToFinished);
+        this.finishingPartitionManager = new FinishingPartitionManager(connectorConfig, partitionManager::updateToFinished);
         this.finishPartitionWatchDog = new FinishPartitionWatchDog(finishingPartitionManager, FINISHING_PARTITION_TIMEOUT, tokens -> {
             processFailure(new FinishingPartitionTimeout(tokens));
         });

--- a/src/main/java/io/debezium/connector/spanner/db/SpannerChangeStreamFactory.java
+++ b/src/main/java/io/debezium/connector/spanner/db/SpannerChangeStreamFactory.java
@@ -25,11 +25,19 @@ public class SpannerChangeStreamFactory {
     private final DaoFactory daoFactory;
     private final MetricsEventPublisher metricsEventPublisher;
     private final String connectorName;
+<<<<<<< HEAD
     private final Dialect dialect;
 
     public SpannerChangeStreamFactory(
                                       DaoFactory daoFactory, MetricsEventPublisher metricsEventPublisher, String connectorName,
                                       Dialect dialect) {
+=======
+    private final String taskUid;
+
+    public SpannerChangeStreamFactory(
+                                      String taskUid, DaoFactory daoFactory, MetricsEventPublisher metricsEventPublisher, String connectorName) {
+        this.taskUid = taskUid;
+>>>>>>> 75d0fe2 (DBZ-6227 Reduce CPU usage and ensure critical logs have task Uid)
         this.daoFactory = daoFactory;
         this.metricsEventPublisher = metricsEventPublisher;
         this.connectorName = connectorName;
@@ -47,7 +55,7 @@ public class SpannerChangeStreamFactory {
         ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(dialect);
 
         SpannerChangeStreamService streamService = new SpannerChangeStreamService(
-                changeStreamDao, changeStreamRecordMapper, heartbeatMillis, metricsEventPublisher);
+                taskUid, changeStreamDao, changeStreamRecordMapper, heartbeatMillis, metricsEventPublisher);
 
         return new SpannerChangeStream(
                 streamService, metricsEventPublisher, heartbeatMillis, maxMissedHeartbeats);

--- a/src/main/java/io/debezium/connector/spanner/db/SpannerChangeStreamFactory.java
+++ b/src/main/java/io/debezium/connector/spanner/db/SpannerChangeStreamFactory.java
@@ -25,19 +25,13 @@ public class SpannerChangeStreamFactory {
     private final DaoFactory daoFactory;
     private final MetricsEventPublisher metricsEventPublisher;
     private final String connectorName;
-<<<<<<< HEAD
     private final Dialect dialect;
-
-    public SpannerChangeStreamFactory(
-                                      DaoFactory daoFactory, MetricsEventPublisher metricsEventPublisher, String connectorName,
-                                      Dialect dialect) {
-=======
     private final String taskUid;
 
-    public SpannerChangeStreamFactory(
-                                      String taskUid, DaoFactory daoFactory, MetricsEventPublisher metricsEventPublisher, String connectorName) {
+    public SpannerChangeStreamFactory(String taskUid,
+                                      DaoFactory daoFactory, MetricsEventPublisher metricsEventPublisher, String connectorName,
+                                      Dialect dialect) {
         this.taskUid = taskUid;
->>>>>>> 75d0fe2 (DBZ-6227 Reduce CPU usage and ensure critical logs have task Uid)
         this.daoFactory = daoFactory;
         this.metricsEventPublisher = metricsEventPublisher;
         this.connectorName = connectorName;

--- a/src/main/java/io/debezium/connector/spanner/db/stream/SpannerChangeStreamService.java
+++ b/src/main/java/io/debezium/connector/spanner/db/stream/SpannerChangeStreamService.java
@@ -87,11 +87,11 @@ public class SpannerChangeStreamService {
             }
         }
         finally {
-            LOGGER.info("Task {}, Stopped streaming from partition", taskUid, token);
+            LOGGER.info("Task {}, Stopped streaming from partition {}", taskUid, token);
         }
 
         partitionEventListener.onFinish(partition);
-        LOGGER.info("Finished consuming partition {}", partition);
+        LOGGER.info("Task {}, Finished consuming partition {}", taskUid, partition);
 
         changeStreamEventConsumer.acceptChangeStreamEvent(new FinishPartitionEvent(partition));
     }

--- a/src/main/java/io/debezium/connector/spanner/kafka/internal/TaskSyncPublisher.java
+++ b/src/main/java/io/debezium/connector/spanner/kafka/internal/TaskSyncPublisher.java
@@ -91,7 +91,6 @@ public class TaskSyncPublisher {
             lastTime = Instant.now();
         }
         catch (ExecutionException e) {
-            close();
             errorHandler.accept(new SpannerConnectorException("Error during publishing to the Sync Topic", e));
         }
         catch (InterruptedException e) {

--- a/src/main/java/io/debezium/connector/spanner/task/LowWatermarkCalculationJob.java
+++ b/src/main/java/io/debezium/connector/spanner/task/LowWatermarkCalculationJob.java
@@ -88,8 +88,8 @@ public class LowWatermarkCalculationJob {
 
     private Thread createCalculationThread() {
         Thread thread = new Thread(() -> {
+            Stopwatch sw = Stopwatch.accumulating().start();
             while (true) {
-                Stopwatch sw = Stopwatch.accumulating().start();
                 try {
                     lock.lock();
                     try {

--- a/src/main/java/io/debezium/connector/spanner/task/TaskSyncContextHolder.java
+++ b/src/main/java/io/debezium/connector/spanner/task/TaskSyncContextHolder.java
@@ -37,7 +37,7 @@ public class TaskSyncContextHolder {
 
     private final AtomicReference<TaskSyncContext> taskSyncContextRef = new AtomicReference<>();
 
-    private final Duration sleepInterval = Duration.ofMillis(1000);
+    private final Duration sleepInterval = Duration.ofMillis(100);
     private final Clock clock;
 
     public TaskSyncContextHolder(MetricsEventPublisher metricsEventPublisher) {

--- a/src/test/java/io/debezium/connector/spanner/FinishingPartitionManagerTest.java
+++ b/src/test/java/io/debezium/connector/spanner/FinishingPartitionManagerTest.java
@@ -15,8 +15,9 @@ class FinishingPartitionManagerTest {
     @Test
     void commitRecord() throws InterruptedException {
         BlockingConsumer<String> consumer = Mockito.mock(BlockingConsumer.class);
+        SpannerConnectorConfig config = Mockito.mock(SpannerConnectorConfig.class);
 
-        FinishingPartitionManager finishingPartitionManager = new FinishingPartitionManager(consumer);
+        FinishingPartitionManager finishingPartitionManager = new FinishingPartitionManager(config, consumer);
 
         finishingPartitionManager.registerPartition("testToken");
 
@@ -32,8 +33,9 @@ class FinishingPartitionManagerTest {
     @Test
     void onPartitionFinishEvent() throws InterruptedException {
         BlockingConsumer<String> consumer = Mockito.mock(BlockingConsumer.class);
+        SpannerConnectorConfig config = Mockito.mock(SpannerConnectorConfig.class);
 
-        FinishingPartitionManager finishingPartitionManager = new FinishingPartitionManager(consumer);
+        FinishingPartitionManager finishingPartitionManager = new FinishingPartitionManager(config, consumer);
 
         finishingPartitionManager.registerPartition("testToken");
 
@@ -50,7 +52,8 @@ class FinishingPartitionManagerTest {
     void forceFinish() throws InterruptedException {
         BlockingConsumer<String> consumer = Mockito.mock(BlockingConsumer.class);
 
-        FinishingPartitionManager finishingPartitionManager = new FinishingPartitionManager(consumer);
+        SpannerConnectorConfig config = Mockito.mock(SpannerConnectorConfig.class);
+        FinishingPartitionManager finishingPartitionManager = new FinishingPartitionManager(config, consumer);
 
         finishingPartitionManager.registerPartition("testToken");
 
@@ -64,8 +67,9 @@ class FinishingPartitionManagerTest {
     @Test
     void withoutRegistration() throws InterruptedException {
         BlockingConsumer<String> consumer = Mockito.mock(BlockingConsumer.class);
+        SpannerConnectorConfig config = Mockito.mock(SpannerConnectorConfig.class);
 
-        FinishingPartitionManager finishingPartitionManager = new FinishingPartitionManager(consumer);
+        FinishingPartitionManager finishingPartitionManager = new FinishingPartitionManager(config, consumer);
 
         finishingPartitionManager.newRecord("testToken");
 
@@ -81,8 +85,9 @@ class FinishingPartitionManagerTest {
     @Test
     void multipleCommitFinishEventFirst() throws InterruptedException {
         BlockingConsumer<String> consumer = Mockito.mock(BlockingConsumer.class);
+        SpannerConnectorConfig config = Mockito.mock(SpannerConnectorConfig.class);
 
-        FinishingPartitionManager finishingPartitionManager = new FinishingPartitionManager(consumer);
+        FinishingPartitionManager finishingPartitionManager = new FinishingPartitionManager(config, consumer);
 
         finishingPartitionManager.registerPartition("testToken");
 
@@ -110,8 +115,9 @@ class FinishingPartitionManagerTest {
     @Test
     void multipleCommitCommitFirst1() throws InterruptedException {
         BlockingConsumer<String> consumer = Mockito.mock(BlockingConsumer.class);
+        SpannerConnectorConfig config = Mockito.mock(SpannerConnectorConfig.class);
 
-        FinishingPartitionManager finishingPartitionManager = new FinishingPartitionManager(consumer);
+        FinishingPartitionManager finishingPartitionManager = new FinishingPartitionManager(config, consumer);
 
         finishingPartitionManager.registerPartition("testToken");
 
@@ -139,8 +145,9 @@ class FinishingPartitionManagerTest {
     @Test
     void multipleCommitCommitFirst2() throws InterruptedException {
         BlockingConsumer<String> consumer = Mockito.mock(BlockingConsumer.class);
+        SpannerConnectorConfig config = Mockito.mock(SpannerConnectorConfig.class);
 
-        FinishingPartitionManager finishingPartitionManager = new FinishingPartitionManager(consumer);
+        FinishingPartitionManager finishingPartitionManager = new FinishingPartitionManager(config, consumer);
 
         finishingPartitionManager.registerPartition("testToken");
 
@@ -168,8 +175,9 @@ class FinishingPartitionManagerTest {
     @Test
     void multipleCommitCommitOutOfOrder() throws InterruptedException {
         BlockingConsumer<String> consumer = Mockito.mock(BlockingConsumer.class);
+        SpannerConnectorConfig config = Mockito.mock(SpannerConnectorConfig.class);
 
-        FinishingPartitionManager finishingPartitionManager = new FinishingPartitionManager(consumer);
+        FinishingPartitionManager finishingPartitionManager = new FinishingPartitionManager(config, consumer);
 
         finishingPartitionManager.registerPartition("testToken");
 
@@ -195,8 +203,9 @@ class FinishingPartitionManagerTest {
     @Test
     void multipleCommitNoEvents() throws InterruptedException {
         BlockingConsumer<String> consumer = Mockito.mock(BlockingConsumer.class);
+        SpannerConnectorConfig config = Mockito.mock(SpannerConnectorConfig.class);
 
-        FinishingPartitionManager finishingPartitionManager = new FinishingPartitionManager(consumer);
+        FinishingPartitionManager finishingPartitionManager = new FinishingPartitionManager(config, consumer);
 
         finishingPartitionManager.registerPartition("testToken");
 
@@ -212,8 +221,9 @@ class FinishingPartitionManagerTest {
     @Test
     void multipleCommitNoEventsWithWrongCommitCall() throws InterruptedException {
         BlockingConsumer<String> consumer = Mockito.mock(BlockingConsumer.class);
+        SpannerConnectorConfig config = Mockito.mock(SpannerConnectorConfig.class);
 
-        FinishingPartitionManager finishingPartitionManager = new FinishingPartitionManager(consumer);
+        FinishingPartitionManager finishingPartitionManager = new FinishingPartitionManager(config, consumer);
 
         finishingPartitionManager.registerPartition("testToken");
 
@@ -231,8 +241,9 @@ class FinishingPartitionManagerTest {
     @Test
     void multipleCommitNoEventsWithWrongCommitCallOnly() throws InterruptedException {
         BlockingConsumer<String> consumer = Mockito.mock(BlockingConsumer.class);
+        SpannerConnectorConfig config = Mockito.mock(SpannerConnectorConfig.class);
 
-        FinishingPartitionManager finishingPartitionManager = new FinishingPartitionManager(consumer);
+        FinishingPartitionManager finishingPartitionManager = new FinishingPartitionManager(config, consumer);
 
         finishingPartitionManager.registerPartition("testToken");
 

--- a/src/test/java/io/debezium/connector/spanner/SpannerStreamingChangeEventSourceTest.java
+++ b/src/test/java/io/debezium/connector/spanner/SpannerStreamingChangeEventSourceTest.java
@@ -134,7 +134,7 @@ class SpannerStreamingChangeEventSourceTest {
         SynchronizedPartitionManager partitionManager = new SynchronizedPartitionManager(
                 (BlockingConsumer<TaskStateChangeEvent>) mock(BlockingConsumer.class));
         SpannerStreamingChangeEventSource spannerStreamingChangeEventSource = new SpannerStreamingChangeEventSource(
-                errorHandler, null, eventQueue, metricsEventPublisher, partitionManager, new SchemaRegistry("Stream Name",
+                connectorConfig2, errorHandler, null, eventQueue, metricsEventPublisher, partitionManager, new SchemaRegistry("Stream Name",
                         new SchemaDao(mock(DatabaseClient.class)), mock(Runnable.class)),
                 spannerEventDispatcher, true, mock(SpannerOffsetContextFactory.class));
         Configuration configuration5 = mock(Configuration.class);
@@ -253,7 +253,7 @@ class SpannerStreamingChangeEventSourceTest {
         doNothing().when(schemaRegistryDatabaseClient).checkSchema(any(), any(), any());
 
         SpannerStreamingChangeEventSource spannerStreamingChangeEventSource = new SpannerStreamingChangeEventSource(
-                errorHandler, null, eventQueue, metricsEventPublisher, partitionManager,
+                new SpannerConnectorConfig(configuration5), errorHandler, null, eventQueue, metricsEventPublisher, partitionManager,
                 schemaRegistryDatabaseClient, spannerEventDispatcher, true, offsetContextFactory);
         Timestamp commitTimestamp = Timestamp.ofTimeMicroseconds(1L);
         ArrayList<Column> rowType = new ArrayList<>();
@@ -270,7 +270,7 @@ class SpannerStreamingChangeEventSourceTest {
         SynchronizedPartitionManager partitionManager = spy(new SynchronizedPartitionManager((BlockingConsumer<TaskStateChangeEvent>) mock(BlockingConsumer.class)));
 
         SpannerStreamingChangeEventSource spannerStreamingChangeEventSource = new SpannerStreamingChangeEventSource(
-                null, null, null, null, partitionManager, new SchemaRegistry(
+                null, null, null, null, null, partitionManager, new SchemaRegistry(
                         "Stream Name", new SchemaDao(mock(DatabaseClient.class)), mock(Runnable.class)),
                 null, true, mock(SpannerOffsetContextFactory.class));
 
@@ -284,7 +284,7 @@ class SpannerStreamingChangeEventSourceTest {
         SynchronizedPartitionManager partitionManager = new SynchronizedPartitionManager((BlockingConsumer<TaskStateChangeEvent>) mock(BlockingConsumer.class));
 
         SpannerStreamingChangeEventSource spannerStreamingChangeEventSource = new SpannerStreamingChangeEventSource(
-                null, null, null, null, partitionManager, new SchemaRegistry(
+                null, null, null, null, null, partitionManager, new SchemaRegistry(
                         "Stream Name", new SchemaDao(mock(DatabaseClient.class)), mock(Runnable.class)),
                 null, true, mock(SpannerOffsetContextFactory.class));
 

--- a/src/test/java/io/debezium/connector/spanner/db/SpannerChangeStreamFactoryTest.java
+++ b/src/test/java/io/debezium/connector/spanner/db/SpannerChangeStreamFactoryTest.java
@@ -24,7 +24,7 @@ class SpannerChangeStreamFactoryTest {
                 new DatabaseClientFactory(
                         "myproject", "42", "42", "Credentials Json", "Credentials Path", null, "test-role"));
         SpannerChangeStreamFactory spannerChangeStreamFactory = new SpannerChangeStreamFactory(
-                daoFactory, new MetricsEventPublisher(), "test-connector",
+                "taskUid", daoFactory, new MetricsEventPublisher(), "test-connector",
                 Dialect.GOOGLE_STANDARD_SQL);
         SpannerChangeStream stream = spannerChangeStreamFactory.getStream("stream1",
                 Duration.ofMillis(100), 1);

--- a/src/test/java/io/debezium/connector/spanner/db/stream/SpannerChangeStreamServiceTest.java
+++ b/src/test/java/io/debezium/connector/spanner/db/stream/SpannerChangeStreamServiceTest.java
@@ -29,15 +29,16 @@ import io.debezium.connector.spanner.metrics.MetricsEventPublisher;
 class SpannerChangeStreamServiceTest {
 
     @Test
-    void testGetEvents() throws InterruptedException {
+    void testGetEvents() throws InterruptedException, Exception {
         ChangeStreamDao changeStreamDao = mock(ChangeStreamDao.class);
         ChangeStreamResultSet changeStreamResultSet = mock(ChangeStreamResultSet.class);
         MetricsEventPublisher metricsEventPublisher = mock(MetricsEventPublisher.class);
         when(changeStreamResultSet.next()).thenReturn(false);
         when(changeStreamDao.streamQuery(any(), any(), any(), anyLong())).thenReturn(changeStreamResultSet);
 
-        SpannerChangeStreamService spannerChangeStreamService = new SpannerChangeStreamService(changeStreamDao,
+        SpannerChangeStreamService spannerChangeStreamService = new SpannerChangeStreamService("TaskUid", changeStreamDao,
                 new ChangeStreamRecordMapper(Dialect.GOOGLE_STANDARD_SQL), Duration.ofMillis(1000), metricsEventPublisher);
+
         HashSet<String> parentTokens = new HashSet<>();
         Timestamp startTimestamp = Timestamp.ofTimeMicroseconds(1L);
         Partition partition = new Partition("token", parentTokens, startTimestamp, Timestamp.ofTimeMicroseconds(1L), "originParent");


### PR DESCRIPTION
Remove Deadlock in BufferedPublisher, increase sleep time in some threads, and ensure critical logs have taskUid.