### PR TITLE
DBZ-6178 Fix mistake not using the passed index

### DIFF
--- a/src/main/java/io/debezium/connector/spanner/db/dao/SchemaDao.java
+++ b/src/main/java/io/debezium/connector/spanner/db/dao/SchemaDao.java
@@ -59,7 +59,7 @@ public class SchemaDao {
         if (isPostgres()) {
             return Objects.equals(resultSet.getString(index), "YES");
         }
-        return resultSet.getBoolean(0);
+        return resultSet.getBoolean(index);
     }
 
     public ChangeStreamSchema getStream(Timestamp timestamp, String streamName) {


### PR DESCRIPTION
There was a mistake in the last commit which used 0 always instead of the passed index.
@jpechane @nancyxu123 