### PR TITLE
DBZ-6262 Enable pass through configurations for sync topic and rebalancing topic

### DIFF
--- a/src/main/java/io/debezium/connector/spanner/SpannerConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/spanner/SpannerConnectorConfig.java
@@ -5,14 +5,10 @@
  */
 package io.debezium.connector.spanner;
 
-import static org.apache.commons.lang3.StringUtils.substringAfter;
-
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
-import java.util.AbstractMap;
 import java.util.Map;
 import java.util.Properties;
-import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.clients.CommonClientConfigs;
@@ -79,21 +75,17 @@ public class SpannerConnectorConfig extends BaseSpannerConnectorConfig {
 
     public Properties kafkaProps(Map<?, ?> props) {
         Properties properties = new Properties();
+        Map<String, String> spannerKafkaProps = this.getConfig()
+                .subset(KAFKA_INTERNAL_CLIENT_CONFIG_PREFIX, true).asMap();
+        if (!spannerKafkaProps.isEmpty()) {
+            properties.putAll(spannerKafkaProps);
+        }
         properties.setProperty(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, this.bootStrapServer());
         properties.put("max.request.size", 104858800);
         properties.put("max.partition.fetch.bytes", 104858800);
 
         properties.putAll(props);
 
-        Map<String, String> spannerKafkaProps = this.getConfig().asMap().entrySet()
-                .stream()
-                .filter(e -> e.getKey().startsWith(KAFKA_INTERNAL_CLIENT_CONFIG_PREFIX))
-                .map(e -> new AbstractMap.SimpleEntry<>(substringAfter(e.getKey(), KAFKA_INTERNAL_CLIENT_CONFIG_PREFIX), e.getValue()))
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-
-        if (!spannerKafkaProps.isEmpty()) {
-            properties.putAll(spannerKafkaProps);
-        }
         return properties;
     }
 

--- a/src/main/java/io/debezium/connector/spanner/config/BaseSpannerConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/spanner/config/BaseSpannerConnectorConfig.java
@@ -60,6 +60,7 @@ public abstract class BaseSpannerConnectorConfig extends CommonConnectorConfig {
     private static final String CONNECTOR_SPANNER_REBALANCING_POLL_DURATION_PROPERTY_NAME = "connector.spanner.rebalancing.poll.duration";
     private static final String CONNECTOR_SPANNER_REBALANCING_COMMIT_OFFSETS_TIMEOUT_PROPERTY_NAME = "connector.spanner.rebalancing.commit.offsets.timeout";
     private static final String CONNECTOR_SPANNER_REBALANCING_COMMIT_OFFSET_INTERVAL_MS_PROPERTY_NAME = "connector.spanner.rebalancing.commit.offset.interval.ms";
+    public static final String CONNECTOR_SPANNER_REBALANCING_TOPIC_CONFIG_PREFIX = "connector.spanner.rebalancing.topic.config.";
     private static final String CONNECTOR_SPANNER_SYNC_POLL_DURATION_PROPERTY_NAME = "connector.spanner.sync.poll.duration";
     private static final String CONNECTOR_SPANNER_SYNC_REQUEST_TIMEOUT_PROPERTY_NAME = "connector.spanner.sync.request.timeout.ms";
     private static final String CONNECTOR_SPANNER_SYNC_DELIVERY_TIMEOUT_PROPERTY_NAME = "connector.spanner.sync.delivery.timeout.ms";
@@ -71,7 +72,7 @@ public abstract class BaseSpannerConnectorConfig extends CommonConnectorConfig {
     private static final String CONNECTOR_SPANNER_SYNC_SEGMENT_MS_POLICY_PROPERTY_NAME = "connector.spanner.sync.segment.ms";
     private static final String CONNECTOR_SPANNER_SYNC_MIN_CLEANABLE_DIRTY_RATIO_PROPERTY_NAME = "connector.spanner.sync.min.cleanable.dirty.ratio";
     private static final String CONNECTOR_SPANNER_SYNC_KAFKA_BOOTSTRAP_SERVERS_PROPERTY_NAME = "connector.spanner.sync.kafka.bootstrap.servers";
-    public static final String CONNECTOR_SPANNER_SYNC_TOPIC_INTERNAL_PREFIX = "connector.spanner.sync.topic.internal.";
+    public static final String CONNECTOR_SPANNER_SYNC_TOPIC_CONFIG_PREFIX = "connector.spanner.sync.topic.config.";
 
     private static final String CONNECTOR_SPANNER_PARTITION_FINISHING_AFTER_COMMIT_PROPERTY_NAME = "connector.spanner.partition.finishing.afterCommit";
 

--- a/src/main/java/io/debezium/connector/spanner/config/BaseSpannerConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/spanner/config/BaseSpannerConnectorConfig.java
@@ -71,6 +71,7 @@ public abstract class BaseSpannerConnectorConfig extends CommonConnectorConfig {
     private static final String CONNECTOR_SPANNER_SYNC_SEGMENT_MS_POLICY_PROPERTY_NAME = "connector.spanner.sync.segment.ms";
     private static final String CONNECTOR_SPANNER_SYNC_MIN_CLEANABLE_DIRTY_RATIO_PROPERTY_NAME = "connector.spanner.sync.min.cleanable.dirty.ratio";
     private static final String CONNECTOR_SPANNER_SYNC_KAFKA_BOOTSTRAP_SERVERS_PROPERTY_NAME = "connector.spanner.sync.kafka.bootstrap.servers";
+    public static final String CONNECTOR_SPANNER_SYNC_TOPIC_INTERNAL_PREFIX = "connector.spanner.sync.topic.internal.";
 
     private static final String CONNECTOR_SPANNER_PARTITION_FINISHING_AFTER_COMMIT_PROPERTY_NAME = "connector.spanner.partition.finishing.afterCommit";
 


### PR DESCRIPTION
Enable the user to configure arbitrary configurations for sync topic with prefix "connector.spanner.sync.topic.config.*" and  for rebalancing topic with prefix "connector.spanner.rebalancing.topic.config.*".

Context: https://debezium.zulipchat.com/#narrow/stream/302529-users/topic/High.20CPU.20consumption.20in.20Spanner.20debezium/near/344217302

For example, this pr will enable users to configure the compression type for sync topic and rebalancing topic in config JSON file by setting:  
~~~~
"connector.spanner.sync.topic.config.compression.type" : "gzip",
"connector.spanner.rebalancing.topic.config.compression.type":"snappy",
~~~~

Tested:
![Screenshot 2023-04-05 at 11 37 38 AM](https://user-images.githubusercontent.com/43364656/230174929-e6a05b02-6009-467f-af89-e49b65ace350.png)
![Screenshot 2023-04-05 at 11 38 01 AM](https://user-images.githubusercontent.com/43364656/230174943-ab64ff26-5784-44f0-bbfb-9e8b46442e82.png)

