### PR TITLE
DBZ-6307 Add manual schema update from stale timestamp

### DIFF
--- a/src/main/java/io/debezium/connector/spanner/db/dao/SchemaDao.java
+++ b/src/main/java/io/debezium/connector/spanner/db/dao/SchemaDao.java
@@ -202,7 +202,7 @@ public class SchemaDao {
         return tx.executeQuery(statement);
     }
 
-    private boolean isPostgres() {
+    public boolean isPostgres() {
         return this.databaseClient.getDialect() == Dialect.POSTGRESQL;
     }
 }

--- a/src/main/java/io/debezium/connector/spanner/db/metadata/SchemaRegistry.java
+++ b/src/main/java/io/debezium/connector/spanner/db/metadata/SchemaRegistry.java
@@ -109,7 +109,6 @@ public class SchemaRegistry {
 
     public void updateSchemaFromStaleTimestamp(TableId tableId, Timestamp timestamp, List<Column> rowType) {
         LOGGER.info("Schema is outdated. Try to update schema registry outside of retention period...");
-        // TableSchema watchedTable = this.getWatchedTable(tableId);
         SpannerSchema.SpannerSchemaBuilder builder = SpannerSchema.builder();
         Dialect dialect = this.schemaDao.isPostgres() ? Dialect.POSTGRESQL : Dialect.GOOGLE_STANDARD_SQL;
         for (Column column : rowType) {
@@ -166,13 +165,5 @@ public class SchemaRegistry {
             throw new IllegalStateException("database schema is not cached yet");
         }
         return this.spannerSchema.getAllTables();
-    }
-
-    @VisibleForTesting
-    TableSchema getTable(TableId tableId) {
-        if (this.spannerSchema == null) {
-            throw new IllegalStateException("database schema is not cached yet");
-        }
-        return this.spannerSchema.getTable(tableId);
     }
 }

--- a/src/main/java/io/debezium/connector/spanner/task/SynchronizationTaskContext.java
+++ b/src/main/java/io/debezium/connector/spanner/task/SynchronizationTaskContext.java
@@ -188,7 +188,7 @@ public class SynchronizationTaskContext {
 
             this.lowWatermarkCalculationJob.start();
 
-            this.schemaRegistry.init(taskSyncContextHolder.get().getDatabaseSchemaTimestamp());
+            this.schemaRegistry.init();
 
             this.taskStateChangeEventProcessor.startProcessing();
 

--- a/src/test/java/io/debezium/connector/spanner/db/metadata/SchemaRegistryTest.java
+++ b/src/test/java/io/debezium/connector/spanner/db/metadata/SchemaRegistryTest.java
@@ -153,6 +153,5 @@ class SchemaRegistryTest {
         schemaRegistry.updateSchemaFromStaleTimestamp(tableId, timestamp, rowType);
         assertEquals(1, schemaRegistry.getAllTables().size());
         assertEquals("Name", schemaRegistry.getAllTables().iterator().next().getTableName());
-        assertEquals(2, schemaRegistry.getTable(tableId).columns().size());
     }
 }


### PR DESCRIPTION
Add a manual schema update function to enable connector to start from stale timestamp. From now on, schema will be initialized at current timestamp. If untracked schema changes are detected from earlier timestamp out of Spanner instance's retention period, we do a manual schema update. This pr is tested with integration tests under both googlesql and postgres dialect.
I will update the debezium doc regarding this change together with the update for pass through configurations from this [pr.](https://github.com/debezium/debezium-connector-spanner/pull/32)