### PR TITLE
DBZ-6544 detect dead tasks and remove duplicate partitions

### DIFF
--- a/src/main/java/io/debezium/connector/spanner/task/LowWatermarkCalculator.java
+++ b/src/main/java/io/debezium/connector/spanner/task/LowWatermarkCalculator.java
@@ -62,8 +62,7 @@ public class LowWatermarkCalculator {
 
         Set<String> duplicatesInPartitions = checkDuplication(partitionsMap);
         if (!duplicatesInPartitions.isEmpty()) {
-            LOGGER.warn(
-                    "calculateLowWatermark: found duplication in partitionsMap: {}", duplicatesInPartitions);
+            LOGGER.warn("calculateLowWatermark: found duplication in partitionsMap: {}", duplicatesInPartitions);
             return null;
         }
 

--- a/src/main/java/io/debezium/connector/spanner/task/SyncEventMerger.java
+++ b/src/main/java/io/debezium/connector/spanner/task/SyncEventMerger.java
@@ -16,6 +16,7 @@ import java.util.stream.Stream;
 
 import org.slf4j.Logger;
 
+import io.debezium.connector.spanner.kafka.internal.model.RebalanceState;
 import io.debezium.connector.spanner.kafka.internal.model.TaskState;
 import io.debezium.connector.spanner.kafka.internal.model.TaskSyncEvent;
 
@@ -32,8 +33,21 @@ public class SyncEventMerger {
     public static TaskSyncContext merge(TaskSyncContext context, TaskSyncEvent inSync) {
         Map<String, TaskState> newTaskStatesMap = inSync.getTaskStates();
         debug(LOGGER, "merge: state before {}, \nIncoming states: {}", context, newTaskStatesMap);
-
+        boolean is_regular_msg = (context.getRebalanceState().equals(RebalanceState.NEW_EPOCH_STARTED));
         var builder = context.toBuilder();
+        boolean foundDuplication = false;
+        if (is_regular_msg) {
+            TaskState currTaskInSyncMessage = newTaskStatesMap.get(context.getTaskUid());
+            // Skip merge incoming states to current task's state if current task is dead.
+            if (currTaskInSyncMessage == null) {
+                LOGGER.warn("The new message task state map did not contain the task UID: {} in the current map: {}, ignoring message {}, check if task id dead.",
+                        inSync.getTaskUid(), newTaskStatesMap, context.getTaskUid());
+                return builder.build();
+            }
+            if (context.checkDuplication(false, "Before Merge Regular Msg")) {
+                foundDuplication = true;
+            }
+        }
 
         Set<String> updatedStatesUids = new HashSet<>();
 
@@ -47,6 +61,12 @@ public class SyncEventMerger {
             }
 
             TaskState currentTaskState = context.getTaskStates().get(inTaskState.getTaskUid());
+            // Skip merging states from dead task
+            if (is_regular_msg && currentTaskState == null) {
+                LOGGER.warn("The current state task map for {} did not contain the message UID: {}, ignoring message {}", context.getTaskUid(), inSync.getTaskUid(),
+                        inSync);
+                continue;
+            }
             // We only update our internal copy of another task's state, if the state timestamp
             // in the sync event message is greater than the state timestamp of our internal
             // copy of the other task's state.
@@ -73,11 +93,15 @@ public class SyncEventMerger {
 
             debug(LOGGER, "merge: final state {}, \nUpdated uids: {}, epoch: {}",
                     result, updatedStatesUids, result.getRebalanceGenerationId());
+            if (is_regular_msg && !foundDuplication && result.checkDuplication(false, "After Merge Regular Msg")) {
+                LOGGER.warn("Duplication exists after merge regular msg on Task {},  old context {}", result.getTaskUid(), context);
+                LOGGER.warn("Duplication exists after merge regular msg on Task {}, a new message {}", result.getTaskUid(), inSync);
+                LOGGER.warn("Duplication exists after merge regular msg on Task {}, resulting context {}", result.getTaskUid(), result);
+            }
 
             return result;
         }
         LOGGER.debug("merge: final state is not changed");
-
         return builder.build();
     }
 

--- a/src/main/java/io/debezium/connector/spanner/task/TaskSyncContext.java
+++ b/src/main/java/io/debezium/connector/spanner/task/TaskSyncContext.java
@@ -6,15 +6,24 @@
 package io.debezium.connector.spanner.task;
 
 import static java.util.Collections.emptyList;
+import static org.slf4j.LoggerFactory.getLogger;
 
 import java.time.Instant;
+import java.util.AbstractMap;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
 
 import com.google.cloud.Timestamp;
 
 import io.debezium.connector.spanner.SpannerConnectorConfig;
 import io.debezium.connector.spanner.kafka.internal.model.MessageTypeEnum;
+import io.debezium.connector.spanner.kafka.internal.model.PartitionState;
+import io.debezium.connector.spanner.kafka.internal.model.PartitionStateEnum;
 import io.debezium.connector.spanner.kafka.internal.model.RebalanceState;
 import io.debezium.connector.spanner.kafka.internal.model.TaskState;
 import io.debezium.connector.spanner.kafka.internal.model.TaskSyncEvent;
@@ -41,6 +50,7 @@ public class TaskSyncContext {
     private final boolean finished;
 
     private final boolean initialized;
+    private static final Logger LOGGER = getLogger(TaskSyncContext.class);
 
     public Map<String, TaskState> getAllTaskStates() {
         Map<String, TaskState> taskStateMap = new HashMap<>(this.taskStates);
@@ -352,5 +362,68 @@ public class TaskSyncContext {
                 ", createdTimestamp=" + this.getCreatedTimestamp() +
                 ", taskStates=" + this.getTaskStates() +
                 ", currentTaskState=" + this.getCurrentTaskState() + ")";
+    }
+
+    public boolean checkDuplication(boolean printOffsets, String loggingString) {
+        Set<String> otherTaskStates = getTaskStates().values().stream().map(task -> task.getTaskUid()).collect(Collectors.toSet());
+        boolean containsCurrentTask = otherTaskStates.contains(getCurrentTaskState().getTaskUid());
+        if (containsCurrentTask) {
+            LOGGER.warn(
+                    "task: {}, logging {}, taskSyncContext: found current task in task states map", getTaskUid(), loggingString);
+            return true;
+        }
+        Map<String, List<PartitionState>> partitionsMap = getAllTaskStates().values().stream()
+                .flatMap(taskState -> taskState.getPartitions().stream())
+                .filter(
+                        partitionState -> !partitionState.getState().equals(PartitionStateEnum.FINISHED)
+                                && !partitionState.getState().equals(PartitionStateEnum.REMOVED))
+                .collect(Collectors.groupingBy(PartitionState::getToken));
+
+        int numPartitions = partitionsMap.size();
+
+        Set<String> duplicatesInPartitions = checkDuplicationInMap(partitionsMap);
+        if (!duplicatesInPartitions.isEmpty()) {
+            if (printOffsets) {
+                LOGGER.warn(
+                        "task: {}, logging {}, taskSyncContext: found duplication in partitionsMap with size {}: {}", getTaskUid(), loggingString, numPartitions,
+                        duplicatesInPartitions);
+            }
+            return true;
+        }
+
+        Map<String, PartitionState> partitions = partitionsMap.entrySet().stream()
+                .map(entry -> new AbstractMap.SimpleEntry<>(entry.getKey(), entry.getValue().get(0)))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        Map<String, List<PartitionState>> sharedPartitionsMap = getAllTaskStates().values().stream()
+                .flatMap(taskState -> taskState.getSharedPartitions().stream())
+                .filter(partitionState -> !partitions.containsKey(partitionState.getToken()))
+                .collect(Collectors.groupingBy(PartitionState::getToken));
+
+        int numSharedPartitions = sharedPartitionsMap.size();
+
+        Set<String> duplicatesInSharedPartitions = checkDuplicationInMap(sharedPartitionsMap);
+        if (!duplicatesInSharedPartitions.isEmpty()) {
+            if (printOffsets) {
+                LOGGER.warn(
+                        "task: {}, logging {}, taskSyncContext: found duplication in sharedPartitionsMap with size {}: {}",
+                        getTaskUid(), loggingString, numSharedPartitions, duplicatesInSharedPartitions);
+            }
+            return true;
+        }
+        if (printOffsets) {
+            LOGGER.warn(
+                    "task: {}, logging {}, taskSyncContext: counted num partitions {} and num shared partitions {} ",
+                    getTaskUid(), loggingString, numPartitions,
+                    numSharedPartitions);
+        }
+        return false;
+    }
+
+    private Set<String> checkDuplicationInMap(Map<String, List<PartitionState>> map) {
+        return map.entrySet().stream()
+                .filter(entry -> entry.getValue().size() > 1)
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toUnmodifiableSet());
     }
 }

--- a/src/main/java/io/debezium/connector/spanner/task/operation/ClearSharedPartitionOperation.java
+++ b/src/main/java/io/debezium/connector/spanner/task/operation/ClearSharedPartitionOperation.java
@@ -32,8 +32,11 @@ public class ClearSharedPartitionOperation implements Operation {
         Set<String> tokens = taskSyncContext.getTaskStates().values().stream().flatMap(taskState -> taskState.getPartitions().stream()).map(PartitionState::getToken)
                 .collect(Collectors.toSet());
 
+        Set<String> otherTasks = taskSyncContext.getTaskStates().values().stream().map(taskState -> taskState.getTaskUid()).collect(Collectors.toSet());
+
         List<PartitionState> newSharedList = currentTaskState.getSharedPartitions().stream()
                 .filter(state -> !tokens.contains(state.getToken()))
+                .filter(state -> otherTasks.contains(state.getAssigneeTaskUid()))
                 .collect(Collectors.toList());
 
         if (newSharedList.size() != currentTaskState.getSharedPartitions().size()) {


### PR DESCRIPTION
This pr detects the dead tasks and remove the duplicate partitions yielded from dead tasks. 
1. When the leader is trying to publish a new epoch message, if the leader did not receive answers from all expected consumers, an exception will be thrown instead of a regular new epoch message.
2. When processing an incoming new epoch message, if the current task is not included in the new epoch message, current task is probably dead and we remove the duplicate partitions in current task if other alive tasks have same partition tokens and lower id.
3. When processing a regular message, we won't proceed either if current task is dead(not include in the new regular message) or the task that current task is trying to merge with is dead.
4. When removing the shared partitions in RemoveSharedPartitions operation, we add a filter to filter out the duplicate partitions exist in more than one task.
This pr is tested with manual test by triggering rebalance events multiple times and check the watermark/partition number. It is also tested with all existed integration test.