### PR TITLE
DBZ-6670 Adapting to constructor changes in ErrorHandler

### DIFF
--- a/src/main/java/io/debezium/connector/spanner/SpannerErrorHandler.java
+++ b/src/main/java/io/debezium/connector/spanner/SpannerErrorHandler.java
@@ -29,7 +29,7 @@ public class SpannerErrorHandler extends ErrorHandler {
     private final SpannerConnectorTask task;
 
     public SpannerErrorHandler(SpannerConnectorTask task, ChangeEventQueue<?> queue) {
-        super(SpannerConnector.class, null, queue);
+        super(SpannerConnector.class, null, queue, null);
         this.task = task;
         this.queue = queue;
     }


### PR DESCRIPTION
Relates to https://github.com/debezium/debezium/pull/4678

@nancyxu123  Seems that spanner connector treats any exception as retriable and always uses infinit retries so there is no point in propagating previous error handler. 