### PR TITLE
DBZ-6685 fix partition duplication

### DIFF
--- a/src/main/java/io/debezium/connector/spanner/task/LowWatermarkCalculationJob.java
+++ b/src/main/java/io/debezium/connector/spanner/task/LowWatermarkCalculationJob.java
@@ -29,7 +29,7 @@ public class LowWatermarkCalculationJob {
 
     private volatile Thread calculationThread;
 
-    private final Duration pollInterval = Duration.ofMillis(60000);
+    private final Duration pollInterval = Duration.ofMillis(600000);
 
     private final Consumer<Throwable> errorHandler;
     private final boolean enabled;

--- a/src/main/java/io/debezium/connector/spanner/task/SyncEventHandler.java
+++ b/src/main/java/io/debezium/connector/spanner/task/SyncEventHandler.java
@@ -149,8 +149,14 @@ public class SyncEventHandler {
 
         taskSyncContextHolder.lock();
         try {
-
             if (!taskSyncContextHolder.get().getRebalanceState().equals(RebalanceState.NEW_EPOCH_STARTED)) {
+                return;
+            }
+
+            if (inSync.getMessageType() == MessageTypeEnum.NEW_EPOCH
+                    || inSync.getMessageType() == MessageTypeEnum.REBALANCE_ANSWER) {
+                LOGGER.warn("Task {} - should have already processed sync message from task {} with message type {}",
+                        taskSyncContextHolder.get().getTaskUid(), inSync.getTaskUid(), inSync.getMessageType());
                 return;
             }
 

--- a/src/main/java/io/debezium/connector/spanner/task/SyncEventHandler.java
+++ b/src/main/java/io/debezium/connector/spanner/task/SyncEventHandler.java
@@ -157,7 +157,6 @@ public class SyncEventHandler {
                     || inSync.getMessageType() == MessageTypeEnum.REBALANCE_ANSWER) {
                 LOGGER.warn("Task {} - should have already processed sync message from task {} with message type {}",
                         taskSyncContextHolder.get().getTaskUid(), inSync.getTaskUid(), inSync.getMessageType());
-                return;
             }
 
             LOGGER.debug("Task {} - process sync event", taskSyncContextHolder.get().getTaskUid());

--- a/src/main/java/io/debezium/connector/spanner/task/SyncEventMerger.java
+++ b/src/main/java/io/debezium/connector/spanner/task/SyncEventMerger.java
@@ -48,6 +48,11 @@ public class SyncEventMerger {
 
         var builder = context.toBuilder();
 
+        // Skip processing messages that this task has already produced.
+        if (inSync.getTaskUid().equals(context.getTaskUid())) {
+            return builder.build();
+        }
+
         Set<String> updatedStatesUids = new HashSet<>();
 
         // We only update our internal copies of other task states from received sync event messages.
@@ -96,7 +101,6 @@ public class SyncEventMerger {
             if (inSync.getMessageType() != MessageTypeEnum.REGULAR && !foundDuplication) {
                 if (result.checkDuplication(true, inSync.getMessageType().toString())) {
                     LOGGER.info("Task {} found duplication after processing {}", context.getTaskUid(), inSync);
-                    LOGGER.info("Task {} final message {}", context.getTaskUid(), result);
                 }
             }
 

--- a/src/main/java/io/debezium/connector/spanner/task/TaskSyncContext.java
+++ b/src/main/java/io/debezium/connector/spanner/task/TaskSyncContext.java
@@ -370,8 +370,8 @@ public class TaskSyncContext {
         if (!duplicatesInPartitions.isEmpty()) {
             if (printOffsets) {
                 LOGGER.warn(
-                        "task: {}, logging {}, taskSyncContext: found duplication in partitionsMap with size {}: {}, {}", getTaskUid(), loggingString, numPartitions,
-                        duplicatesInPartitions, getAllTaskStates());
+                        "task: {}, logging {}, taskSyncContext: found duplication in partitionsMap with size {}: {}", getTaskUid(), loggingString, numPartitions,
+                        duplicatesInPartitions);
             }
             return true;
         }
@@ -391,8 +391,8 @@ public class TaskSyncContext {
         if (!duplicatesInSharedPartitions.isEmpty()) {
             if (printOffsets) {
                 LOGGER.warn(
-                        "task: {}, logging {}, taskSyncContext: found duplication in sharedPartitionsMap with size {}: {}, {}",
-                        getTaskUid(), loggingString, numSharedPartitions, duplicatesInSharedPartitions, getAllTaskStates());
+                        "task: {}, logging {}, taskSyncContext: found duplication in sharedPartitionsMap with size {}: {}",
+                        getTaskUid(), loggingString, numSharedPartitions, duplicatesInSharedPartitions);
             }
             return true;
         }


### PR DESCRIPTION
There can be potential partition duplication after rebalance events when there is only one leader task. in that scenario, the leader will not wait to receive rebalance answer messages before initializing the state to NEW_EPOCH_STARTED. In that event, it can potentially process its own stale rebalance answer message (with the same rebalance generation ID) after initializing the state to NEW_EPOCH_STARTED.

In this event, we need to avoid processing both rebalance answers and new epoch messages in SyncEventHandler::process. We should also filter out messages produced by the same task Uid inside SyncEventMerger.merge.