### PR TITLE
DBZ-6885 Support for GKE workload identities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,6 +190,16 @@
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>${version.mockito}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-inline</artifactId>
+                <version>${version.mockito}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
                 <artifactId>mockito-junit-jupiter</artifactId>
                 <version>${version.mockito}</version>
             </dependency>
@@ -297,6 +307,16 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/io/debezium/connector/spanner/config/BaseSpannerConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/spanner/config/BaseSpannerConnectorConfig.java
@@ -181,7 +181,7 @@ public abstract class BaseSpannerConnectorConfig extends CommonConnectorConfig {
             .withType(Type.STRING)
             .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR, 1))
             .withWidth(Width.MEDIUM)
-            .withImportance(Importance.HIGH)
+            .withImportance(Importance.LOW)
             .withValidation(FieldValidator::isCorrectPath)
             .withDescription("Service account keys file path");
 
@@ -190,7 +190,7 @@ public abstract class BaseSpannerConnectorConfig extends CommonConnectorConfig {
             .withType(Type.STRING)
             .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR, 2))
             .withWidth(Width.LONG)
-            .withImportance(Importance.HIGH)
+            .withImportance(Importance.LOW)
             .withValidation(FieldValidator::isCorrectJson)
             .withDescription("Service account keys with json format");
 

--- a/src/main/java/io/debezium/connector/spanner/config/BaseSpannerConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/spanner/config/BaseSpannerConnectorConfig.java
@@ -181,7 +181,7 @@ public abstract class BaseSpannerConnectorConfig extends CommonConnectorConfig {
             .withType(Type.STRING)
             .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR, 1))
             .withWidth(Width.MEDIUM)
-            .withImportance(Importance.LOW)
+            .withImportance(Importance.MEDIUM)
             .withValidation(FieldValidator::isCorrectPath)
             .withDescription("Service account keys file path");
 
@@ -190,7 +190,7 @@ public abstract class BaseSpannerConnectorConfig extends CommonConnectorConfig {
             .withType(Type.STRING)
             .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR, 2))
             .withWidth(Width.LONG)
-            .withImportance(Importance.LOW)
+            .withImportance(Importance.MEDIUM)
             .withValidation(FieldValidator::isCorrectJson)
             .withDescription("Service account keys with json format");
 

--- a/src/main/java/io/debezium/connector/spanner/config/validation/ConnectionValidator.java
+++ b/src/main/java/io/debezium/connector/spanner/config/validation/ConnectionValidator.java
@@ -22,7 +22,7 @@ public class ConnectionValidator implements ConfigurationValidator.Validator {
 
     private static final String GOOGLE_APPLICATION_CREDENTIALS_ENV_VAR = "GOOGLE_APPLICATION_CREDENTIALS";
 
-    private static final String PLEASE_SPECIFY_CONFIGURATION_PROPERTY_MSG = "please specify configuration property %s or %s or set %s evn variable";
+    private static final String PLEASE_SPECIFY_CONFIGURATION_PROPERTY_MSG = "Configuration property %s or %s is not specified; Application Default Credentials will be used.";
 
     private static final String GOOGLE_CREDENTIAL_INCORRECT = "Can`t connect to spanner. Google credential is incorrect";
     private static final String INSTANCE_NOT_EXIST = "Instance %s does not exist";
@@ -56,10 +56,7 @@ public class ConnectionValidator implements ConfigurationValidator.Validator {
         if (!FieldValidator.isSpecified(googleCredentials) && !FieldValidator.isSpecified(credentialPath) && !FieldValidator.isSpecified(credentialJson)) {
             String message = String.format(PLEASE_SPECIFY_CONFIGURATION_PROPERTY_MSG, SPANNER_CREDENTIALS_PATH.name(),
                     SPANNER_CREDENTIALS_JSON.name(), GOOGLE_APPLICATION_CREDENTIALS_ENV_VAR);
-            LOGGER.error(message);
-            context.error(message, SPANNER_CREDENTIALS_PATH, SPANNER_CREDENTIALS_JSON);
-            result = false;
-            return this;
+            LOGGER.warn(message, SPANNER_CREDENTIALS_PATH, SPANNER_CREDENTIALS_JSON);
         }
         return this;
     }

--- a/src/main/java/io/debezium/connector/spanner/config/validation/ConnectionValidator.java
+++ b/src/main/java/io/debezium/connector/spanner/config/validation/ConnectionValidator.java
@@ -12,6 +12,10 @@ import static io.debezium.connector.spanner.config.BaseSpannerConnectorConfig.SP
 import static io.debezium.connector.spanner.config.BaseSpannerConnectorConfig.SPANNER_CREDENTIALS_PATH;
 import static org.slf4j.LoggerFactory.getLogger;
 
+import java.io.IOException;
+
+import com.google.auth.oauth2.ServiceAccountCredentials;
+
 import org.slf4j.Logger;
 
 /**
@@ -54,6 +58,14 @@ public class ConnectionValidator implements ConfigurationValidator.Validator {
         String credentialJson = context.getString(SPANNER_CREDENTIALS_JSON);
 
         if (!FieldValidator.isSpecified(googleCredentials) && !FieldValidator.isSpecified(credentialPath) && !FieldValidator.isSpecified(credentialJson)) {
+            try {
+                ServiceAccountCredentials.getApplicationDefault();
+            }
+            catch (IOException e) {
+                LOGGER.error("The Application Default Credentials are not available.", e);
+                this.result = false;
+                return this;
+            }
             String message = String.format(PLEASE_SPECIFY_CONFIGURATION_PROPERTY_MSG, SPANNER_CREDENTIALS_PATH.name(),
                     SPANNER_CREDENTIALS_JSON.name(), GOOGLE_APPLICATION_CREDENTIALS_ENV_VAR);
             LOGGER.info(message, SPANNER_CREDENTIALS_PATH, SPANNER_CREDENTIALS_JSON);

--- a/src/main/java/io/debezium/connector/spanner/config/validation/ConnectionValidator.java
+++ b/src/main/java/io/debezium/connector/spanner/config/validation/ConnectionValidator.java
@@ -56,7 +56,7 @@ public class ConnectionValidator implements ConfigurationValidator.Validator {
         if (!FieldValidator.isSpecified(googleCredentials) && !FieldValidator.isSpecified(credentialPath) && !FieldValidator.isSpecified(credentialJson)) {
             String message = String.format(PLEASE_SPECIFY_CONFIGURATION_PROPERTY_MSG, SPANNER_CREDENTIALS_PATH.name(),
                     SPANNER_CREDENTIALS_JSON.name(), GOOGLE_APPLICATION_CREDENTIALS_ENV_VAR);
-            LOGGER.warn(message, SPANNER_CREDENTIALS_PATH, SPANNER_CREDENTIALS_JSON);
+            LOGGER.info(message, SPANNER_CREDENTIALS_PATH, SPANNER_CREDENTIALS_JSON);
         }
         return this;
     }

--- a/src/main/java/io/debezium/connector/spanner/config/validation/ConnectionValidator.java
+++ b/src/main/java/io/debezium/connector/spanner/config/validation/ConnectionValidator.java
@@ -14,9 +14,9 @@ import static org.slf4j.LoggerFactory.getLogger;
 
 import java.io.IOException;
 
-import com.google.auth.oauth2.ServiceAccountCredentials;
-
 import org.slf4j.Logger;
+
+import com.google.auth.oauth2.ServiceAccountCredentials;
 
 /**
  * Checks if the connection to database could be established by given configuration

--- a/src/main/java/io/debezium/connector/spanner/db/DatabaseClientFactory.java
+++ b/src/main/java/io/debezium/connector/spanner/db/DatabaseClientFactory.java
@@ -14,6 +14,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.api.gax.rpc.FixedHeaderProvider;
 import com.google.auth.oauth2.GoogleCredentials;
+import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.cloud.spanner.DatabaseClient;
 import com.google.cloud.spanner.DatabaseId;
 import com.google.cloud.spanner.Spanner;
@@ -93,6 +94,15 @@ public class DatabaseClientFactory {
             }
             catch (IOException e) {
                 LOGGER.error("Error read GOOGLE CREDENTIALS from path {}", credentialsPath);
+                LOGGER.error(e.getMessage(), e);
+            }
+        }
+        else {
+            try {
+                credential = ServiceAccountCredentials.getApplicationDefault();
+            }
+            catch (IOException e) {
+                LOGGER.error("The Application Default Credentials are not available.");
                 LOGGER.error(e.getMessage(), e);
             }
         }

--- a/src/test/java/io/debezium/connector/spanner/config/validation/ConnectionValidatorTest.java
+++ b/src/test/java/io/debezium/connector/spanner/config/validation/ConnectionValidatorTest.java
@@ -5,17 +5,22 @@
  */
 package io.debezium.connector.spanner.config.validation;
 
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.spy;
 
+import java.io.IOException;
 import java.util.Map;
 import java.util.stream.Stream;
 
 import org.apache.kafka.common.config.ConfigValue;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.MockedStatic;
+
+import com.google.auth.oauth2.GoogleCredentials;
 
 import io.debezium.config.Configuration;
 
@@ -27,31 +32,66 @@ class ConnectionValidatorTest {
                         Configuration.from(Map.of(
                                 "gcp.spanner.project.id", "boxwood-weaver-353315",
                                 "gcp.spanner.instance.id", "kafka-connector",
-                                "gcp.spanner.credentials.path", "no_path",
-                                "gcp.spanner.database.id", "kafkaspan")),
-                        true),
+                                "gcp.spanner.database.id", "kafkaspan",
+                                "gcp.spanner.credentials.path", "/path/to/credential"))),
                 Arguments.of(
-                        Configuration.from(Map.of()),
-                        false));
+                        Configuration.from(Map.of(
+                                "gcp.spanner.project.id", "boxwood-weaver-353315",
+                                "gcp.spanner.instance.id", "kafka-connector",
+                                "gcp.spanner.database.id", "kafkaspan",
+                                "gcp.spanner.credentials.json", "{}"))),
+                Arguments.of(
+                        Configuration.from(Map.of(
+                                "gcp.spanner.project.id", "boxwood-weaver-353315",
+                                "gcp.spanner.instance.id", "kafka-connector",
+                                "gcp.spanner.database.id", "kafkaspan"))));
     }
 
-    @Disabled
     @ParameterizedTest
     @MethodSource("configProvider")
-    void validate(Configuration configuration, boolean isSuccess) {
-        Map<String, ConfigValue> configValueMap = Map.of(
-                "gcp.spanner.project.id", new ConfigValue("gcp.spanner.project.id"),
-                "gcp.spanner.instance.id", new ConfigValue("gcp.spanner.instance.id"),
-                "gcp.spanner.database.id", new ConfigValue("gcp.spanner.database.id"),
-                "gcp.spanner.credentials.json", new ConfigValue("gcp.spanner.credentials.json"),
-                "gcp.spanner.credentials.path", new ConfigValue("gcp.spanner.credentials.path"));
+    void validateSuccess(Configuration configuration) {
+        try (MockedStatic<GoogleCredentials> credentials = mockStatic(GoogleCredentials.class)) {
+            credentials.when(GoogleCredentials::getApplicationDefault).thenReturn(null);
 
-        ConfigurationValidator.ValidationContext validationContext = new ConfigurationValidator.ValidationContext(configuration, configValueMap);
+            Map<String, ConfigValue> configValueMap = Map.of(
+                    "gcp.spanner.project.id", new ConfigValue("gcp.spanner.project.id"),
+                    "gcp.spanner.instance.id", new ConfigValue("gcp.spanner.instance.id"),
+                    "gcp.spanner.database.id", new ConfigValue("gcp.spanner.database.id"),
+                    "gcp.spanner.credentials.json", new ConfigValue("gcp.spanner.credentials.json"),
+                    "gcp.spanner.credentials.path", new ConfigValue("gcp.spanner.credentials.path"));
 
-        ConnectionValidator connectionValidator = spy(ConnectionValidator.withContext(validationContext));
-        // doNothing().when(connectionValidator).tryConnectByCredentialsJsonPath();
+            ConfigurationValidator.ValidationContext validationContext = new ConfigurationValidator.ValidationContext(configuration, configValueMap);
+            ConnectionValidator connectionValidator = spy(ConnectionValidator.withContext(validationContext));
 
-        connectionValidator.validate();
-        Assertions.assertEquals(isSuccess, connectionValidator.isSuccess());
+            Assertions.assertTrue(connectionValidator.isSuccess());
+            connectionValidator.validate();
+            Assertions.assertTrue(connectionValidator.isSuccess());
+        }
+    }
+
+    @Test
+    void validateNotSuccess() {
+        Configuration configuration = Configuration.from(Map.of(
+                "gcp.spanner.project.id", "boxwood-weaver-353315",
+                "gcp.spanner.instance.id", "kafka-connector",
+                "gcp.spanner.database.id", "kafkaspan"));
+
+        try (MockedStatic<GoogleCredentials> credentials = mockStatic(GoogleCredentials.class)) {
+            credentials.when(GoogleCredentials::getApplicationDefault).thenThrow(new IOException());
+
+            Map<String, ConfigValue> configValueMap = Map.of(
+                    "gcp.spanner.project.id", new ConfigValue("gcp.spanner.project.id"),
+                    "gcp.spanner.instance.id", new ConfigValue("gcp.spanner.instance.id"),
+                    "gcp.spanner.database.id", new ConfigValue("gcp.spanner.database.id"),
+                    "gcp.spanner.credentials.json", new ConfigValue("gcp.spanner.credentials.json"),
+                    "gcp.spanner.credentials.path", new ConfigValue("gcp.spanner.credentials.path"));
+
+            ConfigurationValidator.ValidationContext validationContext = new ConfigurationValidator.ValidationContext(configuration, configValueMap);
+            ConnectionValidator connectionValidator = spy(ConnectionValidator.withContext(validationContext));
+
+            Assertions.assertTrue(connectionValidator.isSuccess());
+            connectionValidator.validate();
+            Assertions.assertFalse(connectionValidator.isSuccess());
+        }
     }
 }

--- a/src/test/java/io/debezium/connector/spanner/db/DatabaseClientFactoryTest.java
+++ b/src/test/java/io/debezium/connector/spanner/db/DatabaseClientFactoryTest.java
@@ -8,11 +8,16 @@ package io.debezium.connector.spanner.db;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import org.junit.jupiter.api.Test;
+import java.io.IOException;
 
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.spanner.DatabaseClient;
 
 import io.debezium.connector.spanner.SpannerConnectorConfig;
@@ -37,18 +42,21 @@ class DatabaseClientFactoryTest {
 
     @Test
     void testGetGoogleCredentials() {
-        assertNull(new DatabaseClientFactory("myproject", "42", "42", "Credentials Json",
-                "Credentials Path", null, "test-role")
-                .getGoogleCredentials("Credentials Json", "Credentials Path"));
-        assertNull(new DatabaseClientFactory("myproject", "42", "42", "Credentials Json",
-                "Credentials Path", null, "test-role")
-                .getGoogleCredentials(null, null));
-        assertNull(new DatabaseClientFactory("myproject", "42", "42", "Credentials Json",
-                "Credentials Path", null, "test-role")
-                .getGoogleCredentials(null, "Credentials Path"));
-        assertNull(new DatabaseClientFactory("myproject", "42", "42", null,
-                null, null, "test-role")
-                .getGoogleCredentials(null, null));
+        try (MockedStatic<GoogleCredentials> credentials = mockStatic(GoogleCredentials.class)) {
+            credentials.when(GoogleCredentials::getApplicationDefault).thenThrow(new IOException());
+            assertNull(new DatabaseClientFactory("myproject", "42", "42", "Credentials Json",
+                    "Credentials Path", null, "test-role")
+                    .getGoogleCredentials("Credentials Json", "Credentials Path"));
+            assertNull(new DatabaseClientFactory("myproject", "42", "42", "Credentials Json",
+                    "Credentials Path", null, "test-role")
+                    .getGoogleCredentials(null, null));
+            assertNull(new DatabaseClientFactory("myproject", "42", "42", "Credentials Json",
+                    "Credentials Path", null, "test-role")
+                    .getGoogleCredentials(null, "Credentials Path"));
+            assertNull(new DatabaseClientFactory("myproject", "42", "42", null,
+                    null, null, "test-role")
+                    .getGoogleCredentials(null, null));
+        }
     }
 
     @Test

--- a/src/test/java/io/debezium/connector/spanner/db/DatabaseClientFactoryTest.java
+++ b/src/test/java/io/debezium/connector/spanner/db/DatabaseClientFactoryTest.java
@@ -46,7 +46,9 @@ class DatabaseClientFactoryTest {
         assertNull(new DatabaseClientFactory("myproject", "42", "42", "Credentials Json",
                 "Credentials Path", null, "test-role")
                 .getGoogleCredentials(null, "Credentials Path"));
-
+        assertNull(new DatabaseClientFactory("myproject", "42", "42", null,
+                null, null, "test-role")
+                .getGoogleCredentials(null, null));
     }
 
     @Test


### PR DESCRIPTION
### Which use case/requirement will be addressed by the proposed feature?

We are building KafkaConnect on GKE and GKE has a mechanism to authenticate without issuing a ServiceAccount JSON key.
https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity
Since issuing JSON keys is a security risk, we would like to support GKE workload identities with Spanner connectors.

### Implementation ideas (optional)

https://cloud.google.com/docs/authentication
If no JSON key is explicitly set, the Application Default Credentials mechanism can be used for proper authentication processing.

https://issues.redhat.com/browse/DBZ-6885
