### PR TITLE
DBZ-6870 Make the connector robust against rebalance events

### DIFF
--- a/src/main/java/io/debezium/connector/spanner/FinishingPartitionManager.java
+++ b/src/main/java/io/debezium/connector/spanner/FinishingPartitionManager.java
@@ -91,7 +91,7 @@ public class FinishingPartitionManager {
         if (lastEmittedRecord.get(token) == null || lastEmittedRecord.get(token).equals(lastCommittedRecord.get(token))) {
             LOGGER.info("Task: {}, Forcing the token to be finished {}", taskUid, token);
             forceFinish(token);
-            LOGGER.info("Task: {}, Finished forcing the token to be finished {}", taskUid, token);
+            LOGGER.info("Task: {}, Done forcing the token to be finished {}", taskUid, token);
         }
         else {
             LOGGER.info(

--- a/src/main/java/io/debezium/connector/spanner/SpannerConnectorTask.java
+++ b/src/main/java/io/debezium/connector/spanner/SpannerConnectorTask.java
@@ -15,8 +15,6 @@ import org.apache.kafka.connect.source.SourceRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.cloud.spanner.Dialect;
-
 import io.debezium.config.Configuration;
 import io.debezium.connector.base.ChangeEventQueue;
 import io.debezium.connector.spanner.config.SpannerTableFilter;
@@ -93,8 +91,6 @@ public class SpannerConnectorTask extends SpannerBaseSourceTask {
 
         final DaoFactory daoFactory = new DaoFactory(databaseClientFactory);
 
-        final Dialect dialect = databaseClientFactory.getDatabaseClient().getDialect();
-
         final SpannerSourceTaskContext taskContext = new SpannerSourceTaskContext(connectorConfig,
                 () -> spannerMeter.getCapturedTables());
 
@@ -145,7 +141,6 @@ public class SpannerConnectorTask extends SpannerBaseSourceTask {
                 daoFactory,
                 spannerMeter.getMetricsEventPublisher(),
                 connectorConfig.getConnectorName(),
-                dialect,
                 databaseClientFactory);
 
         this.changeStream = spannerChangeStreamFactory.getStream(

--- a/src/main/java/io/debezium/connector/spanner/SpannerStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/spanner/SpannerStreamingChangeEventSource.java
@@ -50,7 +50,7 @@ public class SpannerStreamingChangeEventSource implements CommittingRecordsStrea
 
     private static final StuckPartitionStrategy STUCK_PARTITION_STRATEGY = StuckPartitionStrategy.ESCALATE;
 
-    private static final Duration FINISHING_PARTITION_TIMEOUT = Duration.ofSeconds(60);
+    private static final Duration FINISHING_PARTITION_TIMEOUT = Duration.ofSeconds(300);
 
     private static final long INITIAL_TOKEN_BATCH_SIZE = 200;
 

--- a/src/main/java/io/debezium/connector/spanner/db/DatabaseClientFactory.java
+++ b/src/main/java/io/debezium/connector/spanner/db/DatabaseClientFactory.java
@@ -109,7 +109,7 @@ public class DatabaseClientFactory {
         return credential;
     }
 
-    public synchronized void closeSpanner() {
+    public void closeSpanner() {
         if (spanner == null) {
             return;
         }
@@ -121,11 +121,10 @@ public class DatabaseClientFactory {
         if (spanner == null) {
             return null;
         }
-        if (databaseClient != null) {
-            return databaseClient;
+        if (databaseClient == null) {
+            databaseClient = spanner.getDatabaseClient(
+                    DatabaseId.of(this.projectId, this.instanceId, this.databaseId));
         }
-        databaseClient = spanner.getDatabaseClient(
-                DatabaseId.of(this.projectId, this.instanceId, this.databaseId));
         return databaseClient;
     }
 }

--- a/src/main/java/io/debezium/connector/spanner/db/DatabaseClientFactory.java
+++ b/src/main/java/io/debezium/connector/spanner/db/DatabaseClientFactory.java
@@ -121,9 +121,11 @@ public class DatabaseClientFactory {
         if (spanner == null) {
             return null;
         }
-        if (databaseClient == null) {
-            databaseClient = spanner.getDatabaseClient(
-                    DatabaseId.of(this.projectId, this.instanceId, this.databaseId));
+        synchronized (this) {
+            if (databaseClient == null) {
+                databaseClient = spanner.getDatabaseClient(
+                        DatabaseId.of(this.projectId, this.instanceId, this.databaseId));
+            }
         }
         return databaseClient;
     }

--- a/src/main/java/io/debezium/connector/spanner/db/DatabaseClientFactory.java
+++ b/src/main/java/io/debezium/connector/spanner/db/DatabaseClientFactory.java
@@ -110,18 +110,26 @@ public class DatabaseClientFactory {
     }
 
     public void closeSpanner() {
-        if (spanner == null) {
-            return;
+        synchronized (this) {
+            if (spanner == null) {
+                return;
+            }
+            try {
+                spanner.close();
+            }
+            catch (Exception e) {
+                LOGGER.error("Exception during spanner.close()", e);
+
+            }
+            spanner = null;
         }
-        spanner.close();
-        spanner = null;
     }
 
     public DatabaseClient getDatabaseClient() {
-        if (spanner == null) {
-            return null;
-        }
         synchronized (this) {
+            if (spanner == null) {
+                return null;
+            }
             if (databaseClient == null) {
                 databaseClient = spanner.getDatabaseClient(
                         DatabaseId.of(this.projectId, this.instanceId, this.databaseId));

--- a/src/main/java/io/debezium/connector/spanner/db/SpannerChangeStreamFactory.java
+++ b/src/main/java/io/debezium/connector/spanner/db/SpannerChangeStreamFactory.java
@@ -8,7 +8,6 @@ package io.debezium.connector.spanner.db;
 import java.time.Duration;
 import java.util.UUID;
 
-import com.google.cloud.spanner.Dialect;
 import com.google.cloud.spanner.Options;
 
 import io.debezium.connector.spanner.db.dao.ChangeStreamDao;
@@ -23,21 +22,19 @@ public class SpannerChangeStreamFactory {
     private static final String JOB_NAME = "SpannerChangeStream_Kafka";
 
     private final DaoFactory daoFactory;
-    private final DatabaseClientFactory databaseClientFactory;
     private final MetricsEventPublisher metricsEventPublisher;
     private final String connectorName;
-    private final Dialect dialect;
     private final String taskUid;
+    private final DatabaseClientFactory databaseClientFactory;
 
     public SpannerChangeStreamFactory(String taskUid,
                                       DaoFactory daoFactory, MetricsEventPublisher metricsEventPublisher, String connectorName,
-                                      Dialect dialect, DatabaseClientFactory databaseClientFactory) {
+                                      DatabaseClientFactory databaseClientFactory) {
         this.taskUid = taskUid;
         this.daoFactory = daoFactory;
         this.databaseClientFactory = databaseClientFactory;
         this.metricsEventPublisher = metricsEventPublisher;
         this.connectorName = connectorName;
-        this.dialect = dialect;
     }
 
     public SpannerChangeStream getStream(
@@ -48,7 +45,7 @@ public class SpannerChangeStreamFactory {
                 Options.RpcPriority.MEDIUM,
                 JOB_NAME + "_" + connectorName + "_" + UUID.randomUUID());
 
-        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(dialect);
+        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(databaseClientFactory.getDatabaseClient());
 
         SpannerChangeStreamService streamService = new SpannerChangeStreamService(
                 taskUid, changeStreamDao, changeStreamRecordMapper, heartbeatMillis, metricsEventPublisher);

--- a/src/main/java/io/debezium/connector/spanner/db/mapper/ChangeStreamRecordMapper.java
+++ b/src/main/java/io/debezium/connector/spanner/db/mapper/ChangeStreamRecordMapper.java
@@ -17,6 +17,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.google.cloud.Timestamp;
+import com.google.cloud.spanner.DatabaseClient;
 import com.google.cloud.spanner.Dialect;
 import com.google.cloud.spanner.Struct;
 import com.google.cloud.spanner.Type;
@@ -85,10 +86,10 @@ public class ChangeStreamRecordMapper {
 
     private static final String SYSTEM_TRANSACTION = "is_system_transaction";
 
-    private final Dialect dialect;
+    private final DatabaseClient databaseClient;
 
-    public ChangeStreamRecordMapper(Dialect dialect) {
-        this.dialect = dialect;
+    public ChangeStreamRecordMapper(DatabaseClient databaseClient) {
+        this.databaseClient = databaseClient;
 
         this.printer = JsonFormat.printer().preservingProtoFieldNames()
                 .omittingInsignificantWhitespace();
@@ -482,7 +483,7 @@ public class ChangeStreamRecordMapper {
     }
 
     private boolean isPostgres() {
-        return this.dialect == Dialect.POSTGRESQL;
+        return this.databaseClient.getDialect() == Dialect.POSTGRESQL;
     }
 
 }

--- a/src/main/java/io/debezium/connector/spanner/db/stream/ChangeStream.java
+++ b/src/main/java/io/debezium/connector/spanner/db/stream/ChangeStream.java
@@ -17,8 +17,6 @@ import io.debezium.connector.spanner.db.stream.exception.ChangeStreamException;
 public interface ChangeStream {
     boolean submitPartition(Partition partition);
 
-    void stop(String token);
-
     void stop();
 
     void run(BooleanSupplier runningFlagSupplier, ChangeStreamEventConsumer changeStreamEventConsumer,

--- a/src/main/java/io/debezium/connector/spanner/db/stream/PartitionThreadPool.java
+++ b/src/main/java/io/debezium/connector/spanner/db/stream/PartitionThreadPool.java
@@ -29,6 +29,12 @@ public class PartitionThreadPool {
     private final Clock clock = Clock.system();
 
     public boolean submit(String token, Runnable runnable) {
+        clean();
+
+        if (threadMap.containsKey(token)) {
+            LOGGER.info("Fail to submit token in PartitionThreadPool {} since it is already contained in the map", token);
+        }
+
         AtomicBoolean insertedThread = new AtomicBoolean(false);
 
         threadMap.computeIfAbsent(token, k -> {
@@ -38,10 +44,10 @@ public class PartitionThreadPool {
             return thread;
         });
         if (!insertedThread.get()) {
-            LOGGER.info("Fail to submit token {}", token);
+            LOGGER.info("Fail to submit token in PartitionThreadPool {}", token);
         }
 
-        return true;
+        return insertedThread.get();
     }
 
     public void stop(String token) {

--- a/src/main/java/io/debezium/connector/spanner/db/stream/PartitionThreadPool.java
+++ b/src/main/java/io/debezium/connector/spanner/db/stream/PartitionThreadPool.java
@@ -8,6 +8,7 @@ package io.debezium.connector.spanner.db.stream;
 import java.time.Duration;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.slf4j.Logger;
@@ -22,7 +23,7 @@ import io.debezium.util.Metronome;
 public class PartitionThreadPool {
     private static final Logger LOGGER = LoggerFactory.getLogger(PartitionThreadPool.class);
 
-    private final ConcurrentHashMap<String, Thread> threadMap = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, Thread> threadMap = new ConcurrentHashMap<>();
 
     private final Duration sleepInterval = Duration.ofMillis(100);
 
@@ -32,7 +33,7 @@ public class PartitionThreadPool {
         clean();
 
         if (threadMap.containsKey(token)) {
-            LOGGER.info("Fail to submit token in PartitionThreadPool {} since it is already contained in the map", token);
+            LOGGER.info("Failed to submit token in PartitionThreadPool {} since it is already contained in the map", token);
             return false;
         }
 
@@ -45,7 +46,7 @@ public class PartitionThreadPool {
             return thread;
         });
         if (!insertedThread.get()) {
-            LOGGER.info("Fail to submit token in PartitionThreadPool {}", token);
+            LOGGER.info("Failed to submit token in PartitionThreadPool {}", token);
         }
 
         return insertedThread.get();

--- a/src/main/java/io/debezium/connector/spanner/db/stream/PartitionThreadPool.java
+++ b/src/main/java/io/debezium/connector/spanner/db/stream/PartitionThreadPool.java
@@ -33,6 +33,7 @@ public class PartitionThreadPool {
 
         if (threadMap.containsKey(token)) {
             LOGGER.info("Fail to submit token in PartitionThreadPool {} since it is already contained in the map", token);
+            return false;
         }
 
         AtomicBoolean insertedThread = new AtomicBoolean(false);

--- a/src/main/java/io/debezium/connector/spanner/db/stream/PartitionThreadPool.java
+++ b/src/main/java/io/debezium/connector/spanner/db/stream/PartitionThreadPool.java
@@ -68,6 +68,10 @@ public class PartitionThreadPool {
 
         while (!threadMap.isEmpty() && !threadMap.values().stream().allMatch(thread -> thread.getState().equals(Thread.State.TERMINATED))) {
             try {
+                clean();
+
+                LOGGER.info("Still trying to shut down partition thread poll for task {} and threads {}", taskUid, threadMap.keySet());
+                threadMap.values().forEach(Thread::interrupt);
                 // Sleep for sleepInterval.
                 metronome.pause();
             }

--- a/src/main/java/io/debezium/connector/spanner/db/stream/PartitionThreadPool.java
+++ b/src/main/java/io/debezium/connector/spanner/db/stream/PartitionThreadPool.java
@@ -74,15 +74,6 @@ public class PartitionThreadPool {
                 Thread.currentThread().interrupt();
             }
             LOGGER.info("Beginning to terminate threads, task {}", taskUid);
-            // Map<String, Thread> unterminatedThreads = threadMap.entrySet().stream().filter(entry -> !entry.getValue().getState().equals(Thread.State.TERMINATED))
-            // .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-            // LOGGER.info("Task {}, Found {} unterminated threads {}, task {}", taskUid, unterminatedThreads.size(), unterminatedThreads);
-            // for (Map.Entry<String, Thread> unterminatedThread : unterminatedThreads.entrySet()) {
-            // LOGGER.info("Task {}, trying to terminate the token {} with state {}", taskUid, unterminatedThread.getKey(), unterminatedThread.getValue().getState());
-            // unterminatedThread.getValue().interrupt();
-            // }
-            // LOGGER.info("Finished trying to interrupt threads, cleaning {}", taskUid);
-            // clean();
         }
         LOGGER.info("Successfully shut down partition thread poll for task {}", taskUid);
     }

--- a/src/main/java/io/debezium/connector/spanner/db/stream/PartitionThreadPool.java
+++ b/src/main/java/io/debezium/connector/spanner/db/stream/PartitionThreadPool.java
@@ -32,7 +32,8 @@ public class PartitionThreadPool {
     public synchronized boolean submit(String token, Runnable runnable) {
 
         if (threadMap.containsKey(token)) {
-            LOGGER.info("Failed to submit token {} due to it existing in thread map {}", token, threadMap.keySet().stream().collect(Collectors.toList()));
+            LOGGER.info("Failed to submit token {} due to it existing in thread map {}", token,
+                    threadMap.keySet().stream().collect(Collectors.toList()));
             return false;
         }
 

--- a/src/main/java/io/debezium/connector/spanner/db/stream/PartitionThreadPool.java
+++ b/src/main/java/io/debezium/connector/spanner/db/stream/PartitionThreadPool.java
@@ -76,6 +76,8 @@ public class PartitionThreadPool {
             LOGGER.info("Beginning to terminate threads, task {}", taskUid);
         }
         LOGGER.info("Successfully shut down partition thread poll for task {}", taskUid);
+        clean();
+        LOGGER.info("Successfully cleaned partition thread poll for task {}", taskUid);
     }
 
     private void clean() {

--- a/src/main/java/io/debezium/connector/spanner/db/stream/SpannerChangeStream.java
+++ b/src/main/java/io/debezium/connector/spanner/db/stream/SpannerChangeStream.java
@@ -140,10 +140,10 @@ public class SpannerChangeStream implements ChangeStream {
             }
             catch (Exception ex) {
 
-                LOGGER.info("Exception during streaming {} from partition with token {}", ex.getMessage(), partition.getToken());
+                LOGGER.info("Task {}, Exception during streaming {} from partition with token {}", this.taskUid, ex.getMessage(), partition.getToken());
 
                 if (this.onError(partition, ex)) {
-                    LOGGER.info("Unretriable exception during streaming {} from partition with token {}", ex.getMessage(), partition.getToken());
+                    LOGGER.info("Task {}, Unretriable exception during streaming {} from partition with token {}", this.taskUid, ex.getMessage(), partition.getToken());
                     return;
                 }
 
@@ -157,7 +157,7 @@ public class SpannerChangeStream implements ChangeStream {
                 }
             }
             finally {
-                LOGGER.info("Stopped streaming from partition with token {}", partition.getToken());
+                LOGGER.info("Task {}, Stopped streaming from partition with token {}", this.taskUid, partition.getToken());
             }
         });
 

--- a/src/main/java/io/debezium/connector/spanner/db/stream/SpannerChangeStream.java
+++ b/src/main/java/io/debezium/connector/spanner/db/stream/SpannerChangeStream.java
@@ -115,10 +115,9 @@ public class SpannerChangeStream implements ChangeStream {
             databaseClientFactory.closeSpanner();
 
             LOGGER.info("Task {}, Shutting down all partition streaming...", this.taskUid);
+            this.isRunning.set(false);
             this.partitionThreadPool.shutdown(this.taskUid);
             LOGGER.info("Task {}, Shutdown all partition streaming...", this.taskUid);
-
-            this.isRunning.set(false);
         }
     }
 

--- a/src/main/java/io/debezium/connector/spanner/db/stream/SpannerChangeStream.java
+++ b/src/main/java/io/debezium/connector/spanner/db/stream/SpannerChangeStream.java
@@ -148,6 +148,7 @@ public class SpannerChangeStream implements ChangeStream {
                 }
 
                 try {
+
                     partitionEventListener.onException(partition, ex);
                 }
                 catch (InterruptedException e) {
@@ -182,15 +183,6 @@ public class SpannerChangeStream implements ChangeStream {
         if (this.partitionEventListener.onStuckPartition(token)) {
             this.onError(new StuckPartitionException(token));
         }
-    }
-
-    @Override
-    public void stop(String token) {
-        partitionThreadPool.stop(token);
-
-        metricsEventPublisher.publishMetricEvent(new ActiveQueriesUpdateMetricEvent(partitionThreadPool.getActiveThreads().size()));
-
-        LOGGER.info("Stopped streaming from partition with token {}", token);
     }
 
     @Override

--- a/src/main/java/io/debezium/connector/spanner/db/stream/SpannerChangeStream.java
+++ b/src/main/java/io/debezium/connector/spanner/db/stream/SpannerChangeStream.java
@@ -148,7 +148,6 @@ public class SpannerChangeStream implements ChangeStream {
                 }
 
                 try {
-
                     partitionEventListener.onException(partition, ex);
                 }
                 catch (InterruptedException e) {

--- a/src/main/java/io/debezium/connector/spanner/db/stream/SpannerChangeStream.java
+++ b/src/main/java/io/debezium/connector/spanner/db/stream/SpannerChangeStream.java
@@ -128,6 +128,7 @@ public class SpannerChangeStream implements ChangeStream {
             return false;
         }
 
+        LOGGER.info("task {}, Trying to submit token {}", this.taskUid, partition.getToken());
         boolean submitted = partitionThreadPool.submit(partition.getToken(), () -> {
             LOGGER.info("task {}, Started streaming from partition with token {}", this.taskUid, partition.getToken());
             try {

--- a/src/main/java/io/debezium/connector/spanner/db/stream/SpannerChangeStream.java
+++ b/src/main/java/io/debezium/connector/spanner/db/stream/SpannerChangeStream.java
@@ -93,6 +93,7 @@ public class SpannerChangeStream implements ChangeStream {
         this.partitionQueryingMonitor.start();
 
         this.lock.lock();
+        LOGGER.info("Task {}, Starting Spanner Change Stream", this.taskUid);
 
         try {
             while (runningFlagSupplier.getAsBoolean()) {
@@ -124,11 +125,10 @@ public class SpannerChangeStream implements ChangeStream {
     @Override
     public boolean submitPartition(Partition partition) {
         if (!isRunning.get()) {
-            LOGGER.info("Task {}, Failed to submit partition: {}", this.taskUid, partition.getToken());
+            LOGGER.warn("Task {}, Failed to submit partition: {}", this.taskUid, partition.getToken());
             return false;
         }
 
-        LOGGER.info("task {}, Trying to submit token {}", this.taskUid, partition.getToken());
         boolean submitted = partitionThreadPool.submit(partition.getToken(), () -> {
             LOGGER.info("task {}, Started streaming from partition with token {}", this.taskUid, partition.getToken());
             try {

--- a/src/main/java/io/debezium/connector/spanner/kafka/internal/BufferedPublisher.java
+++ b/src/main/java/io/debezium/connector/spanner/kafka/internal/BufferedPublisher.java
@@ -85,7 +85,7 @@ public class BufferedPublisher<V> {
             if (item.getClass() == TaskSyncEvent.class) {
                 TaskSyncEvent event = (TaskSyncEvent) item;
 
-                LOGGER.debug("Task {}, publishing event with rebalance generation ID {} and message type {}", this.taskUid,
+                LOGGER.info("Task {}, publishing event with rebalance generation ID {} and message type {}", this.taskUid,
                         event.getRebalanceGenerationId(),
                         event.getMessageType());
             }

--- a/src/main/java/io/debezium/connector/spanner/kafka/internal/BufferedPublisher.java
+++ b/src/main/java/io/debezium/connector/spanner/kafka/internal/BufferedPublisher.java
@@ -15,7 +15,6 @@ import java.util.function.Predicate;
 
 import org.slf4j.Logger;
 
-import io.debezium.connector.spanner.kafka.internal.model.TaskState;
 import io.debezium.connector.spanner.kafka.internal.model.TaskSyncEvent;
 import io.debezium.util.Clock;
 import io.debezium.util.Metronome;

--- a/src/main/java/io/debezium/connector/spanner/kafka/internal/BufferedPublisher.java
+++ b/src/main/java/io/debezium/connector/spanner/kafka/internal/BufferedPublisher.java
@@ -102,9 +102,9 @@ public class BufferedPublisher<V> {
             if (item.getClass() == TaskSyncEvent.class) {
                 TaskSyncEvent event = (TaskSyncEvent) item;
 
-                LOGGER.info("Task {}, publishing event with rebalance generation ID {} and message type {}", this.taskUid,
+                LOGGER.info("Task {}, publishing buffered event with rebalance generation ID {} and message type {} and context rebalance state {}", this.taskUid,
                         event.getRebalanceGenerationId(),
-                        event.getMessageType());
+                        event.getMessageType(), context.getRebalanceState());
             }
             this.onPublish.accept(item);
         }

--- a/src/main/java/io/debezium/connector/spanner/kafka/internal/BufferedPublisher.java
+++ b/src/main/java/io/debezium/connector/spanner/kafka/internal/BufferedPublisher.java
@@ -72,6 +72,13 @@ public class BufferedPublisher<V> {
                 this.value.set(null);
                 this.onPublish.accept(update);
             }
+            if (update.getClass() == TaskSyncEvent.class) {
+                TaskSyncEvent event = (TaskSyncEvent) update;
+
+                LOGGER.info("Task {}, publishing event with rebalance generation ID {} and message type {}", this.taskUid,
+                        event.getRebalanceGenerationId(),
+                        event.getMessageType());
+            }
         }
         else {
             value.set(update);

--- a/src/main/java/io/debezium/connector/spanner/kafka/internal/BufferedPublisher.java
+++ b/src/main/java/io/debezium/connector/spanner/kafka/internal/BufferedPublisher.java
@@ -81,7 +81,7 @@ public class BufferedPublisher<V> {
             if (update.getClass() == TaskSyncEvent.class) {
                 TaskSyncEvent event = (TaskSyncEvent) update;
 
-                LOGGER.info("Task {}, publishing event with rebalance generation ID {} and message type {}", this.taskUid,
+                LOGGER.debug("Task {}, publishing event with rebalance generation ID {} and message type {}", this.taskUid,
                         event.getRebalanceGenerationId(),
                         event.getMessageType());
             }
@@ -102,7 +102,7 @@ public class BufferedPublisher<V> {
             if (item.getClass() == TaskSyncEvent.class) {
                 TaskSyncEvent event = (TaskSyncEvent) item;
 
-                LOGGER.info("Task {}, publishing buffered event with rebalance generation ID {} and message type {} and context rebalance state {}", this.taskUid,
+                LOGGER.debug("Task {}, publishing buffered event with rebalance generation ID {} and message type {} and context rebalance state {}", this.taskUid,
                         event.getRebalanceGenerationId(),
                         event.getMessageType(), context.getRebalanceState());
             }

--- a/src/main/java/io/debezium/connector/spanner/kafka/internal/RebalancingEventListener.java
+++ b/src/main/java/io/debezium/connector/spanner/kafka/internal/RebalancingEventListener.java
@@ -141,6 +141,7 @@ public class RebalancingEventListener {
             }
             finally {
                 try {
+                    LOGGER.info("Task {} - unsubscribing rebalance handling consumer", task.getTaskUid());
                     consumer.unsubscribe();
                     consumer.close();
                 }
@@ -161,10 +162,6 @@ public class RebalancingEventListener {
     }
 
     public void shutdown() {
-        if (this.shutDownListener.get() == true) {
-            LOGGER.info("Task {} - Trying to shut down listener, already shut down listener", task.getTaskUid());
-            return;
-        }
         this.shutDownListener.set(true);
         this.resettableDelayedAction.clear();
 

--- a/src/main/java/io/debezium/connector/spanner/kafka/internal/TaskSyncEventListener.java
+++ b/src/main/java/io/debezium/connector/spanner/kafka/internal/TaskSyncEventListener.java
@@ -182,16 +182,13 @@ public class TaskSyncEventListener {
             return 0;
         }
         for (ConsumerRecord<String, byte[]> record : records) {
-
             TaskSyncEvent taskSyncEvent = parseSyncEvent(record);
             debug(LOGGER, "Receive SyncEvent from Kafka topic: {}", taskSyncEvent);
 
             if (record.offset() == endOffset - 1) {
                 LOGGER.info("Task {}, can begin to initiate rebalancing", consumerGroup);
             }
-            int i = 0;
             for (BlockingBiConsumer<TaskSyncEvent, SyncEventMetadata> eventConsumer : eventConsumers) {
-                i++;
                 boolean canInitiateRebalancing = (record.offset() >= endOffset - 1);
                 eventConsumer.accept(
                         taskSyncEvent,

--- a/src/main/java/io/debezium/connector/spanner/kafka/internal/TaskSyncEventListener.java
+++ b/src/main/java/io/debezium/connector/spanner/kafka/internal/TaskSyncEventListener.java
@@ -138,17 +138,20 @@ public class TaskSyncEventListener {
                                 else {
                                     sw.start();
                                 }
+                                LOGGER.info("Task {}, debug polling the sync topic", consumerGroup);
                                 poll(consumer, endOffset);
+                                LOGGER.info("Task {}, done debug polling the sync topic", consumerGroup);
                                 if (!consumerFactory.isAutoCommitEnabled()
                                         && commitOffsetStart + commitOffsetsInterval < System.currentTimeMillis()) {
 
                                     consumer.commitSync(commitOffsetsTimeout);
                                     commitOffsetStart = System.currentTimeMillis();
                                 }
+                                LOGGER.info("Task {}, done committing offset to the sync topic", consumerGroup);
                             }
                             catch (org.apache.kafka.common.errors.InterruptException
                                     | InterruptedException ex) {
-                                LOGGER.info("TaskSyncEventListener, caught interrupt exception {}, {}", consumerGroup, ex);
+                                LOGGER.error("TaskSyncEventListener, caught interrupt exception {}, {}", consumerGroup, ex);
                                 return;
                             }
                             catch (Exception e) {

--- a/src/main/java/io/debezium/connector/spanner/kafka/internal/TaskSyncEventListener.java
+++ b/src/main/java/io/debezium/connector/spanner/kafka/internal/TaskSyncEventListener.java
@@ -138,16 +138,13 @@ public class TaskSyncEventListener {
                                 else {
                                     sw.start();
                                 }
-                                LOGGER.info("Task {}, debug polling the sync topic", consumerGroup);
                                 poll(consumer, endOffset);
-                                LOGGER.info("Task {}, done debug polling the sync topic", consumerGroup);
                                 if (!consumerFactory.isAutoCommitEnabled()
                                         && commitOffsetStart + commitOffsetsInterval < System.currentTimeMillis()) {
 
                                     consumer.commitSync(commitOffsetsTimeout);
                                     commitOffsetStart = System.currentTimeMillis();
                                 }
-                                LOGGER.info("Task {}, done committing offset to the sync topic", consumerGroup);
                             }
                             catch (org.apache.kafka.common.errors.InterruptException
                                     | InterruptedException ex) {
@@ -184,7 +181,6 @@ public class TaskSyncEventListener {
         if (records.isEmpty()) {
             return 0;
         }
-
         for (ConsumerRecord<String, byte[]> record : records) {
 
             TaskSyncEvent taskSyncEvent = parseSyncEvent(record);
@@ -193,7 +189,9 @@ public class TaskSyncEventListener {
             if (record.offset() == endOffset - 1) {
                 LOGGER.info("Task {}, can begin to initiate rebalancing", consumerGroup);
             }
+            int i = 0;
             for (BlockingBiConsumer<TaskSyncEvent, SyncEventMetadata> eventConsumer : eventConsumers) {
+                i++;
                 boolean canInitiateRebalancing = (record.offset() >= endOffset - 1);
                 eventConsumer.accept(
                         taskSyncEvent,

--- a/src/main/java/io/debezium/connector/spanner/kafka/internal/TaskSyncEventListener.java
+++ b/src/main/java/io/debezium/connector/spanner/kafka/internal/TaskSyncEventListener.java
@@ -122,7 +122,7 @@ public class TaskSyncEventListener {
         catch (Exception ex) {
             LOGGER.info("Shutdown consumer {} for ex {}", consumerGroup, ex);
             shutdownConsumer(consumer);
-            throw ex;
+            errorHandler.accept(new RuntimeException(ex));
         }
 
         thread = new Thread(

--- a/src/main/java/io/debezium/connector/spanner/kafka/internal/TaskSyncEventListener.java
+++ b/src/main/java/io/debezium/connector/spanner/kafka/internal/TaskSyncEventListener.java
@@ -107,11 +107,11 @@ public class TaskSyncEventListener {
                     seekBackToPreviousEpoch(consumer, topicPartition, beginOffset, startOffset);
                 }
                 catch (org.apache.kafka.common.errors.InterruptException e) {
-                    LOGGER.info("Task {}, caught interrupt exception during reading the sync topic {}", consumerGroup, e);
+                    LOGGER.info("Task {}, caught interrupt exception during reading the sync topic", consumerGroup, e);
                     throw new InterruptedException();
                 }
                 catch (Exception e) {
-                    LOGGER.info("Task {}, Error during seek back the Sync Topic {}", consumerGroup, e);
+                    LOGGER.info("Task {}, Error during seek back the Sync Topic {}", consumerGroup);
                     errorHandler.accept(
                             new SpannerConnectorException("Error during seek back the Sync Topic", e));
                     return;
@@ -152,7 +152,7 @@ public class TaskSyncEventListener {
                             }
                             catch (org.apache.kafka.common.errors.InterruptException
                                     | InterruptedException ex) {
-                                LOGGER.error("TaskSyncEventListener, caught interrupt exception {}, {}", consumerGroup, ex);
+                                LOGGER.error("TaskSyncEventListener, caught interrupt exception {}", consumerGroup, ex);
                                 Thread.currentThread().interrupt();
                                 return;
                             }

--- a/src/main/java/io/debezium/connector/spanner/kafka/internal/TaskSyncEventListener.java
+++ b/src/main/java/io/debezium/connector/spanner/kafka/internal/TaskSyncEventListener.java
@@ -230,6 +230,7 @@ public class TaskSyncEventListener {
 
         long previousEpochOffset = taskSyncEvent.getEpochOffset();
         long startOffset = Math.max(previousEpochOffset, beginOffset);
+        LOGGER.info("Task {}, listen: found previous epoch offset {} and begin offset {}", consumerGroup, previousEpochOffset, beginOffset);
 
         LOGGER.info("Task {}, listen: seek back to previous epoch offset: {}", consumerGroup, startOffset);
         consumer.seek(topicPartition, startOffset);

--- a/src/main/java/io/debezium/connector/spanner/kafka/internal/TaskSyncPublisher.java
+++ b/src/main/java/io/debezium/connector/spanner/kafka/internal/TaskSyncPublisher.java
@@ -35,7 +35,6 @@ public class TaskSyncPublisher {
     private volatile Instant lastTime;
     private final BufferedPublisher<TaskSyncEvent> bufferedPublisher;
     private final Consumer<RuntimeException> errorHandler;
-    private final TaskSyncContextHolder taskSyncContextHolder;
 
     private final String taskUid;
 
@@ -46,13 +45,12 @@ public class TaskSyncPublisher {
         this.producer = producerFactory.createProducer();
         this.errorHandler = errorHandler;
         this.taskUid = taskUid;
-        this.taskSyncContextHolder = taskSyncContextHolder;
 
         if (syncEventPublisherWaitingTimeout > 0) {
             this.bufferedPublisher = new BufferedPublisher<>(
                     this.taskUid,
                     "Buffer-Pub",
-                    this.taskSyncContextHolder,
+                    taskSyncContextHolder,
                     syncEventPublisherWaitingTimeout,
                     this::publishImmediately,
                     this::publishSyncEvent);

--- a/src/main/java/io/debezium/connector/spanner/task/LowWatermarkCalculationJob.java
+++ b/src/main/java/io/debezium/connector/spanner/task/LowWatermarkCalculationJob.java
@@ -28,7 +28,7 @@ public class LowWatermarkCalculationJob {
 
     private volatile Thread calculationThread;
 
-    private final Duration pollInterval = Duration.ofMillis(60000);
+    private final Duration pollInterval = Duration.ofMillis(300000);
 
     private final Consumer<Throwable> errorHandler;
     private final boolean enabled;

--- a/src/main/java/io/debezium/connector/spanner/task/LowWatermarkCalculationJob.java
+++ b/src/main/java/io/debezium/connector/spanner/task/LowWatermarkCalculationJob.java
@@ -63,13 +63,13 @@ public class LowWatermarkCalculationJob {
                 final Metronome metronome = Metronome.sleeper(Duration.ofMillis(period), clock);
                 LOGGER.info("Task {}, beginning calculation of low watermark", taskUid);
                 while (true) {
-                    LOGGER.info("Task {}, still calculating low watermark", taskUid);
                     try {
                         final Duration totalDuration = sw.stop().durations().statistics().getTotal();
                         boolean printOffsets = false;
                         if (totalDuration.toMillis() >= pollInterval.toMillis()) {
                             // Restart the stopwatch.
                             printOffsets = true;
+                            LOGGER.info("Task {}, still calculating low watermark", taskUid);
                             sw = Stopwatch.accumulating().start();
                         }
                         else {

--- a/src/main/java/io/debezium/connector/spanner/task/LowWatermarkCalculationJob.java
+++ b/src/main/java/io/debezium/connector/spanner/task/LowWatermarkCalculationJob.java
@@ -28,7 +28,7 @@ public class LowWatermarkCalculationJob {
 
     private volatile Thread calculationThread;
 
-    private final Duration pollInterval = Duration.ofMillis(300000);
+    private final Duration pollInterval = Duration.ofMillis(60000);
 
     private final Consumer<Throwable> errorHandler;
     private final boolean enabled;

--- a/src/main/java/io/debezium/connector/spanner/task/LowWatermarkCalculationJob.java
+++ b/src/main/java/io/debezium/connector/spanner/task/LowWatermarkCalculationJob.java
@@ -153,8 +153,7 @@ public class LowWatermarkCalculationJob {
                     // Sleep for sleepInterval.
                     metronome.pause();
 
-                    LOGGER.info("Task {}, interrupting low watermark calculation thread again", taskUid);
-                    this.calculationThread.interrupt();
+                    LOGGER.info("Task {}, still waiting for low watermark calculation thread to die", taskUid);
                 }
                 catch (InterruptedException e) {
                     Thread.currentThread().interrupt();

--- a/src/main/java/io/debezium/connector/spanner/task/LowWatermarkCalculator.java
+++ b/src/main/java/io/debezium/connector/spanner/task/LowWatermarkCalculator.java
@@ -49,7 +49,7 @@ public class LowWatermarkCalculator {
         TaskSyncContext taskSyncContext = taskSyncContextHolder.get();
 
         if (!taskSyncContext.isInitialized()) {
-            LOGGER.warn("TaskSyncContextHolder not initialized");
+            LOGGER.warn("Task {}, TaskSyncContextHolder not initialized", taskSyncContextHolder.get().getTaskUid());
             return null;
         }
 
@@ -63,10 +63,8 @@ public class LowWatermarkCalculator {
         Set<String> duplicatesInPartitions = checkDuplication(partitionsMap);
 
         if (!duplicatesInPartitions.isEmpty()) {
-            if (printOffsets) {
-                LOGGER.warn(
-                        "Task {}, calculateLowWatermark: found duplication in partitionsMap: {}", taskSyncContextHolder.get().getTaskUid(), duplicatesInPartitions);
-            }
+            LOGGER.warn(
+                    "Task {}, calculateLowWatermark: found duplication in partitionsMap: {}", taskSyncContextHolder.get().getTaskUid(), duplicatesInPartitions);
             return null;
         }
 
@@ -81,11 +79,9 @@ public class LowWatermarkCalculator {
 
         Set<String> duplicatesInSharedPartitions = checkDuplication(sharedPartitionsMap);
         if (!duplicatesInSharedPartitions.isEmpty()) {
-            if (printOffsets) {
-                LOGGER.warn(
-                        "Task {}, calculateLowWatermark: found duplication in sharedPartitionsMap: {}",
-                        taskSyncContextHolder.get().getTaskUid(), duplicatesInSharedPartitions);
-            }
+            LOGGER.warn(
+                    "Task {}, calculateLowWatermark: found duplication in sharedPartitionsMap: {}",
+                    taskSyncContextHolder.get().getTaskUid(), duplicatesInSharedPartitions);
             return null;
         }
 

--- a/src/main/java/io/debezium/connector/spanner/task/LowWatermarkCalculator.java
+++ b/src/main/java/io/debezium/connector/spanner/task/LowWatermarkCalculator.java
@@ -49,7 +49,6 @@ public class LowWatermarkCalculator {
         TaskSyncContext taskSyncContext = taskSyncContextHolder.get();
 
         if (!taskSyncContext.isInitialized()) {
-            LOGGER.warn("Task {}, TaskSyncContextHolder not initialized", taskSyncContextHolder.get().getTaskUid());
             return null;
         }
 

--- a/src/main/java/io/debezium/connector/spanner/task/LowWatermarkCalculator.java
+++ b/src/main/java/io/debezium/connector/spanner/task/LowWatermarkCalculator.java
@@ -123,6 +123,7 @@ public class LowWatermarkCalculator {
                 LOGGER.info(
                         "Task {}, Kafka connect offsetStorageReader is interrupting... Thread interrupted: {}",
                         taskSyncContextHolder.get().getTaskUid(), Thread.currentThread().isInterrupted());
+                Thread.currentThread().interrupt();
             }
             else {
                 LOGGER.warn(

--- a/src/main/java/io/debezium/connector/spanner/task/PartitionFactory.java
+++ b/src/main/java/io/debezium/connector/spanner/task/PartitionFactory.java
@@ -51,7 +51,6 @@ public class PartitionFactory {
     }
 
     public Partition getPartition(PartitionState partitionState) {
-        LOGGER.info("Partition factory, getting partition {}", partitionState);
         return Partition.builder()
                 .token(partitionState.getToken())
                 .startTimestamp(getOffset(partitionState))
@@ -61,11 +60,7 @@ public class PartitionFactory {
     }
 
     private Timestamp getOffset(PartitionState partitionState) {
-
-        LOGGER.info("Partition factory, getting offset {}", partitionState);
         final Timestamp offset = partitionOffsetProvider.getOffset(partitionState);
-        LOGGER.info("Partition factory, got partition {}", partitionState);
-
         Timestamp startTime;
 
         if (offset != null) {

--- a/src/main/java/io/debezium/connector/spanner/task/PartitionFactory.java
+++ b/src/main/java/io/debezium/connector/spanner/task/PartitionFactory.java
@@ -51,6 +51,7 @@ public class PartitionFactory {
     }
 
     public Partition getPartition(PartitionState partitionState) {
+        LOGGER.info("Partition factory, getting partition {}", partitionState);
         return Partition.builder()
                 .token(partitionState.getToken())
                 .startTimestamp(getOffset(partitionState))
@@ -61,14 +62,16 @@ public class PartitionFactory {
 
     private Timestamp getOffset(PartitionState partitionState) {
 
-        final Timestamp offset = partitionOffsetProvider.getOffset(partitionState.getToken());
+        LOGGER.info("Partition factory, getting offset {}", partitionState);
+        final Timestamp offset = partitionOffsetProvider.getOffset(partitionState);
+        LOGGER.info("Partition factory, got partition {}", partitionState);
 
         Timestamp startTime;
 
         if (offset != null) {
 
             if (offset.toSqlTimestamp().before(partitionState.getStartTimestamp().toSqlTimestamp())) {
-                Map<String, String> offsetMap = partitionOffsetProvider.getOffsetMap(partitionState.getToken());
+                Map<String, String> offsetMap = partitionOffsetProvider.getOffsetMap(partitionState);
 
                 LOGGER.warn("Incorrect offset, start time will be taken for partition {}, offsetMap {}", partitionState.getToken(), offsetMap);
 

--- a/src/main/java/io/debezium/connector/spanner/task/PartitionOffsetProvider.java
+++ b/src/main/java/io/debezium/connector/spanner/task/PartitionOffsetProvider.java
@@ -10,14 +10,24 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
 import org.apache.kafka.connect.storage.OffsetStorageReader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.cloud.Timestamp;
 
 import io.debezium.connector.spanner.SpannerPartition;
 import io.debezium.connector.spanner.context.offset.PartitionOffset;
+import io.debezium.connector.spanner.kafka.internal.model.PartitionState;
 import io.debezium.connector.spanner.metrics.MetricsEventPublisher;
 import io.debezium.connector.spanner.metrics.event.OffsetReceivingTimeMetricEvent;
 
@@ -26,21 +36,51 @@ import io.debezium.connector.spanner.metrics.event.OffsetReceivingTimeMetricEven
  * and publishes appropriate metrics
  */
 public class PartitionOffsetProvider {
+    private static final Logger LOGGER = LoggerFactory.getLogger(PartitionOffsetProvider.class);
+
     private final OffsetStorageReader offsetStorageReader;
     private final MetricsEventPublisher metricsEventPublisher;
 
-    public PartitionOffsetProvider(OffsetStorageReader offsetStorageReader, MetricsEventPublisher metricsEventPublisherr) {
+    private final ExecutorService executor;
+
+    public PartitionOffsetProvider(OffsetStorageReader offsetStorageReader, MetricsEventPublisher metricsEventPublisher) {
         this.offsetStorageReader = offsetStorageReader;
-        this.metricsEventPublisher = metricsEventPublisherr;
+        this.metricsEventPublisher = metricsEventPublisher;
+        this.executor = Executors.newCachedThreadPool();
     }
 
-    public Timestamp getOffset(String token) {
+    public Timestamp getOffset(PartitionState token) {
         Instant startTime = Instant.now();
+        LOGGER.info("Token {}, Trying to get offset", token);
+        Map<String, String> spannerPartition = new SpannerPartition(token.getToken()).getSourcePartition();
+        LOGGER.info("Token {}, Retrieved spanner partition", token);
 
-        Map<String, ?> result = this.offsetStorageReader.offset(new SpannerPartition(token).getSourcePartition());
+        Map<String, ?> result = null;
+        LOGGER.info("Token {}, Submitting executor task", token);
+        Future<Map<String, ?>> future = executor.submit(new ExecutorServiceCallable(offsetStorageReader, spannerPartition));
+        try {
+            LOGGER.info("Token {}, Retrieving future", token);
+            result = future.get(5, TimeUnit.SECONDS);
+        }
+        catch (TimeoutException ex) {
+            // handle the timeout
+            LOGGER.error("Token {}, failed to retrieve offset timely {}", token, ex);
+        }
+        catch (InterruptedException e) {
+            // handle the interrupts
+            Thread.currentThread().interrupt();
+        }
+        catch (ExecutionException e) {
+            // handle other exceptions
+            LOGGER.error("Token {}, failed to retrieve offset {}", token, e);
+        }
+        finally {
+            future.cancel(true); // may or may not desire this
+        }
 
         if (result == null) {
-            return null;
+            LOGGER.error("Token {}, failed to retrieve offset, returning start timestamp", token);
+            return token.getStartTimestamp();
         }
 
         metricsEventPublisher.publishMetricEvent(OffsetReceivingTimeMetricEvent.from(startTime));
@@ -48,9 +88,12 @@ public class PartitionOffsetProvider {
         return PartitionOffset.extractOffset(result);
     }
 
-    public Map<String, String> getOffsetMap(String token) {
+    public Map<String, String> getOffsetMap(PartitionState token) {
 
-        Map<String, ?> result = this.offsetStorageReader.offset(new SpannerPartition(token).getSourcePartition());
+        LOGGER.info("Token {}, Trying to get offset map", token);
+        Map<String, String> spannerPartition = new SpannerPartition(token.getToken()).getSourcePartition();
+        Map<String, ?> result = this.offsetStorageReader.offset(spannerPartition);
+        LOGGER.info("Token {},  Got offset map", token);
 
         if (result == null) {
             return Map.of();
@@ -65,7 +108,10 @@ public class PartitionOffsetProvider {
                 .map(token -> new SpannerPartition(token).getSourcePartition())
                 .collect(Collectors.toList());
 
+        // LOGGER.info("Token {}, Trying to get offsets", partitions);
         Map<Map<String, String>, Map<String, Object>> result = this.offsetStorageReader.offsets(partitionsMapList);
+
+        // LOGGER.info("Token {}, Got offsets", partitions);
 
         if (result == null) {
             return Map.of();
@@ -81,6 +127,22 @@ public class PartitionOffsetProvider {
         }
 
         return map;
+    }
+
+    public static class ExecutorServiceCallable implements Callable<Map<String, ?>> {
+
+        private OffsetStorageReader offsetStorageReader;
+        private Map<String, String> spannerPartition;
+
+        public ExecutorServiceCallable(OffsetStorageReader offsetStorageReader, Map<String, String> spannerPartition) {
+            offsetStorageReader = offsetStorageReader;
+            spannerPartition = spannerPartition;
+        }
+
+        @Override
+        public Map<String, ?> call() throws Exception {
+            return this.offsetStorageReader.offset(spannerPartition);
+        }
     }
 
 }

--- a/src/main/java/io/debezium/connector/spanner/task/PartitionOffsetProvider.java
+++ b/src/main/java/io/debezium/connector/spanner/task/PartitionOffsetProvider.java
@@ -57,7 +57,7 @@ public class PartitionOffsetProvider {
             LOGGER.warn("Token {} returning start timestamp because no offset was retrieved", token);
             return token.getStartTimestamp();
         }
-
+        LOGGER.info("Successfully retrieved offset {} for token {}", result, token);
         return PartitionOffset.extractOffset(result);
     }
 
@@ -115,7 +115,7 @@ public class PartitionOffsetProvider {
         }
         catch (ExecutionException e) {
             // handle other exceptions
-            LOGGER.error("Token {}, failed to retrieve offset", spannerPartition, e);
+            LOGGER.error("Token {}, failed to retrieve offset {}:{}", spannerPartition, e.toString(), e.getStackTrace());
         }
         finally {
             future.cancel(true); // may or may not desire this
@@ -130,8 +130,8 @@ public class PartitionOffsetProvider {
         private Map<String, String> spannerPartition;
 
         public ExecutorServiceCallable(OffsetStorageReader offsetStorageReader, Map<String, String> spannerPartition) {
-            offsetStorageReader = offsetStorageReader;
-            spannerPartition = spannerPartition;
+            this.offsetStorageReader = offsetStorageReader;
+            this.spannerPartition = spannerPartition;
         }
 
         @Override
@@ -140,7 +140,7 @@ public class PartitionOffsetProvider {
                 return this.offsetStorageReader.offset(spannerPartition);
             }
             catch (Exception e) {
-                LOGGER.error("Offsetstoragereader throwing exception", e);
+                LOGGER.error("Offsetstoragereader throwing exception {}, {}", e.toString(), e.getStackTrace());
                 throw e;
             }
         }

--- a/src/main/java/io/debezium/connector/spanner/task/PartitionOffsetProvider.java
+++ b/src/main/java/io/debezium/connector/spanner/task/PartitionOffsetProvider.java
@@ -140,7 +140,7 @@ public class PartitionOffsetProvider {
                 return this.offsetStorageReader.offset(spannerPartition);
             }
             catch (Exception e) {
-                LOGGER.error("Offsetstoragereader throwing exception {}, {}", e.toString(), e.getStackTrace());
+                LOGGER.error("Offsetstoragereader throwing exception", e);
                 throw e;
             }
         }

--- a/src/main/java/io/debezium/connector/spanner/task/PartitionOffsetProvider.java
+++ b/src/main/java/io/debezium/connector/spanner/task/PartitionOffsetProvider.java
@@ -136,7 +136,13 @@ public class PartitionOffsetProvider {
 
         @Override
         public Map<String, ?> call() throws Exception {
-            return this.offsetStorageReader.offset(spannerPartition);
+            try {
+                return this.offsetStorageReader.offset(spannerPartition);
+            }
+            catch (Exception e) {
+                LOGGER.error("Offsetstoragereader throwing exception {}", e);
+                throw e;
+            }
         }
     }
 

--- a/src/main/java/io/debezium/connector/spanner/task/PartitionOffsetProvider.java
+++ b/src/main/java/io/debezium/connector/spanner/task/PartitionOffsetProvider.java
@@ -106,16 +106,16 @@ public class PartitionOffsetProvider {
         }
         catch (TimeoutException ex) {
             // handle the timeout
-            LOGGER.error("Token {}, failed to retrieve offset in time {}", spannerPartition, ex);
+            LOGGER.error("Token {}, failed to retrieve offset in time", spannerPartition, ex);
         }
         catch (InterruptedException e) {
             // handle the interrupts
-            LOGGER.error("Token {},interrupting PartitionOffsetProvider {}", spannerPartition, e);
+            LOGGER.error("Token {},interrupting PartitionOffsetProvider", spannerPartition, e);
             Thread.currentThread().interrupt();
         }
         catch (ExecutionException e) {
             // handle other exceptions
-            LOGGER.error("Token {}, failed to retrieve offset {}", spannerPartition, e);
+            LOGGER.error("Token {}, failed to retrieve offset", spannerPartition, e);
         }
         finally {
             future.cancel(true); // may or may not desire this
@@ -140,7 +140,7 @@ public class PartitionOffsetProvider {
                 return this.offsetStorageReader.offset(spannerPartition);
             }
             catch (Exception e) {
-                LOGGER.error("Offsetstoragereader throwing exception {}", e);
+                LOGGER.error("Offsetstoragereader throwing exception", e);
                 throw e;
             }
         }

--- a/src/main/java/io/debezium/connector/spanner/task/RebalanceHandler.java
+++ b/src/main/java/io/debezium/connector/spanner/task/RebalanceHandler.java
@@ -76,6 +76,7 @@ public class RebalanceHandler {
                     // stream partitions until after the leader finishes rebalancing change
                     // stream partitions from the obsolete tasks to the new survived tasks.
                     .rebalanceState(RebalanceState.INITIAL_INCREMENTED_STATE_COMPLETED)
+                    .receivedRebalanceGenerationId(rebalanceGenerationId)
                     .build();
         });
 

--- a/src/main/java/io/debezium/connector/spanner/task/RebalanceHandler.java
+++ b/src/main/java/io/debezium/connector/spanner/task/RebalanceHandler.java
@@ -41,10 +41,10 @@ public class RebalanceHandler {
 
     public void process(boolean isLeader, String consumerId, long rebalanceGenerationId) throws InterruptedException {
         LOGGER.info(
-                "processRebalancingEvent: start, consumerId: {}, taskId{}, rebalanceGenerationId: {}, isLeader {}, lock debug info {}",
+                "processRebalancingEvent: start, consumerId: {}, taskId{}, rebalanceGenerationId: {}, isLeader {}",
                 consumerId,
                 taskSyncContextHolder.get().getTaskUid(),
-                rebalanceGenerationId, isLeader, taskSyncContextHolder.lockDebugString());
+                rebalanceGenerationId, isLeader);
 
         TaskSyncContext context = taskSyncContextHolder.updateAndGet(oldContext -> {
             if (rebalanceGenerationId < taskSyncContextHolder.get().getRebalanceGenerationId()) {

--- a/src/main/java/io/debezium/connector/spanner/task/RebalanceHandler.java
+++ b/src/main/java/io/debezium/connector/spanner/task/RebalanceHandler.java
@@ -39,13 +39,12 @@ public class RebalanceHandler {
         this.lowWatermarkStampPublisher = lowWatermarkStampPublisher;
     }
 
-    public synchronized void process(boolean isLeader, String consumerId, long rebalanceGenerationId) throws InterruptedException {
+    public void process(boolean isLeader, String consumerId, long rebalanceGenerationId) throws InterruptedException {
         LOGGER.info(
-                "processRebalancingEvent: start, consumerId: {}, taskId{}, rebalanceGenerationId: {}, isLeader {}, lock debug info {}, lock queue length {}, lock hold count {}, is locked {}, is locked by current thread {}",
+                "processRebalancingEvent: start, consumerId: {}, taskId{}, rebalanceGenerationId: {}, isLeader {}, lock debug info {}",
                 consumerId,
                 taskSyncContextHolder.get().getTaskUid(),
-                rebalanceGenerationId, isLeader, taskSyncContextHolder.lockDebugString(), taskSyncContextHolder.getQueueLength(),
-                taskSyncContextHolder.getHoldCount(), taskSyncContextHolder.isLocked(), taskSyncContextHolder.isLockedByCurrentThread());
+                rebalanceGenerationId, isLeader, taskSyncContextHolder.lockDebugString());
 
         TaskSyncContext context = taskSyncContextHolder.updateAndGet(oldContext -> {
             if (rebalanceGenerationId < taskSyncContextHolder.get().getRebalanceGenerationId()) {
@@ -125,7 +124,7 @@ public class RebalanceHandler {
         this.lowWatermarkStampPublisher.init();
     }
 
-    public synchronized void destroy() {
+    public void destroy() {
         this.leaderAction.stop();
         LOGGER.info("Task {}, destroyed leader action ", taskSyncContextHolder.get().getTaskUid());
 

--- a/src/main/java/io/debezium/connector/spanner/task/RebalanceHandler.java
+++ b/src/main/java/io/debezium/connector/spanner/task/RebalanceHandler.java
@@ -47,7 +47,7 @@ public class RebalanceHandler {
                 rebalanceGenerationId, isLeader);
 
         long oldRebalanceGenerationId = taskSyncContextHolder.get().getRebalanceGenerationId();
-        if (rebalanceGenerationId < oldRebalanceGenerationId) {
+        if (rebalanceGenerationId <= oldRebalanceGenerationId) {
             LOGGER.info(
                     "processRebalancingEvent: skipping due to stale rebalance generation ID {}, consumerId: {}, taskId{}, rebalanceGenerationId: {}, isLeader {}",
                     rebalanceGenerationId, consumerId,

--- a/src/main/java/io/debezium/connector/spanner/task/RebalanceHandler.java
+++ b/src/main/java/io/debezium/connector/spanner/task/RebalanceHandler.java
@@ -47,7 +47,7 @@ public class RebalanceHandler {
                 rebalanceGenerationId, isLeader);
 
         long oldRebalanceGenerationId = taskSyncContextHolder.get().getRebalanceGenerationId();
-        if (rebalanceGenerationId <= oldRebalanceGenerationId) {
+        if (rebalanceGenerationId < oldRebalanceGenerationId) {
             LOGGER.info(
                     "processRebalancingEvent: skipping due to stale rebalance generation ID {}, consumerId: {}, taskId{}, rebalanceGenerationId: {}, isLeader {}",
                     rebalanceGenerationId, consumerId,

--- a/src/main/java/io/debezium/connector/spanner/task/SyncEventHandler.java
+++ b/src/main/java/io/debezium/connector/spanner/task/SyncEventHandler.java
@@ -119,10 +119,10 @@ public class SyncEventHandler {
 
     public void processNewEpoch(TaskSyncEvent inSync, SyncEventMetadata metadata) throws InterruptedException, IllegalStateException {
         LOGGER.info(
-                "Task {} - processNewEpoch: metadata {}, rebalanceId: {}, current task {}",
+                "Task {} - processNewEpoch: metadata {}, rebalance State {}, rebalanceId: {}, current task {}",
                 taskSyncContextHolder.get().getTaskUid(),
-                taskSyncContextHolder.get(),
                 metadata,
+                taskSyncContextHolder.get().getRebalanceState(),
                 inSync.getRebalanceGenerationId());
 
         TaskSyncContext newContext = taskSyncContextHolder.updateAndGet(context -> SyncEventMerger.mergeNewEpoch(context, inSync));

--- a/src/main/java/io/debezium/connector/spanner/task/SyncEventHandler.java
+++ b/src/main/java/io/debezium/connector/spanner/task/SyncEventHandler.java
@@ -46,13 +46,13 @@ public class SyncEventHandler {
             return;
         }
 
-        LOGGER.info("Task {} - before update task sync topic offset with {}", taskSyncContextHolder.get().getTaskUid(), metadata.getOffset());
+        LOGGER.debug("Task {} - before update task sync topic offset with {}", taskSyncContextHolder.get().getTaskUid(), metadata.getOffset());
 
         taskSyncContextHolder.update(oldContext -> oldContext.toBuilder()
                 .currentKafkaRecordOffset(metadata.getOffset())
                 .build());
 
-        LOGGER.info("Task {} - update task sync topic offset with {}", taskSyncContextHolder.get().getTaskUid(), metadata.getOffset());
+        LOGGER.debug("Task {} - update task sync topic offset with {}", taskSyncContextHolder.get().getTaskUid(), metadata.getOffset());
     }
 
     public void processPreviousStates(TaskSyncEvent inSync, SyncEventMetadata metadata) {

--- a/src/main/java/io/debezium/connector/spanner/task/SyncEventHandler.java
+++ b/src/main/java/io/debezium/connector/spanner/task/SyncEventHandler.java
@@ -177,11 +177,8 @@ public class SyncEventHandler {
             // For REGULAR type messages, we filter them out in SyncEventMerger if the preexisting
             // task states map does not contain them, and if the state timestamp is not greater.
 
-            if (inSync.getMessageType() == MessageTypeEnum.NEW_EPOCH) {
-                return inGeneration <= currentGeneration;
-            }
-
-            if (inSync.getMessageType() == MessageTypeEnum.REBALANCE_ANSWER
+            if (inSync.getMessageType() == MessageTypeEnum.NEW_EPOCH
+                    || inSync.getMessageType() == MessageTypeEnum.REBALANCE_ANSWER
                     || inSync.getMessageType() == MessageTypeEnum.UPDATE_EPOCH) {
                 return inGeneration < currentGeneration;
             }

--- a/src/main/java/io/debezium/connector/spanner/task/SyncEventHandler.java
+++ b/src/main/java/io/debezium/connector/spanner/task/SyncEventHandler.java
@@ -114,8 +114,8 @@ public class SyncEventHandler {
             taskSyncContextHolder.update(context -> context.toBuilder()
                     .rebalanceState(RebalanceState.INITIAL_INCREMENTED_STATE_COMPLETED)
                     .build());
-            LOGGER.info("Task {} - now initialized with epoch offset {} and context {}", taskSyncContextHolder.get().getTaskUid(),
-                    taskSyncContextHolder.get().getEpochOffsetHolder().getEpochOffset(), taskSyncContextHolder.get());
+            LOGGER.info("Task {} - now initialized with epoch offset {}", taskSyncContextHolder.get().getTaskUid(),
+                    taskSyncContextHolder.get().getEpochOffsetHolder().getEpochOffset());
 
             // Check that there are no duplicate partitions after the task has finished initializing.
             taskSyncContextHolder.get().checkDuplication(true, "Finished Initializing Task State");

--- a/src/main/java/io/debezium/connector/spanner/task/SyncEventHandler.java
+++ b/src/main/java/io/debezium/connector/spanner/task/SyncEventHandler.java
@@ -63,7 +63,7 @@ public class SyncEventHandler {
             if (inSync != null) {
                 long inGeneration = inSync.getRebalanceGenerationId();
                 long currentGeneration = taskSyncContextHolder.get().getRebalanceGenerationId();
-                LOGGER.debug("Task {}, skipFromMismatchingGeneration: currentGen: {}, inGen: {}, inTaskUid: {}, message type {}",
+                LOGGER.info("Task {}, skipFromMismatchingGeneration: currentGen: {}, inGen: {}, inTaskUid: {}, message type {}",
                         taskSyncContextHolder.get().getTaskUid(),
                         currentGeneration, inGeneration,
                         inSync.getTaskUid(),
@@ -178,8 +178,11 @@ public class SyncEventHandler {
             // For REGULAR type messages, we filter them out in SyncEventMerger if the preexisting
             // task states map does not contain them, and if the state timestamp is not greater.
 
-            if (inSync.getMessageType() == MessageTypeEnum.REBALANCE_ANSWER ||
-                    inSync.getMessageType() == MessageTypeEnum.NEW_EPOCH
+            if (inSync.getMessageType() == MessageTypeEnum.NEW_EPOCH) {
+                return inGeneration <= currentGeneration;
+            }
+
+            if (inSync.getMessageType() == MessageTypeEnum.REBALANCE_ANSWER
                     || inSync.getMessageType() == MessageTypeEnum.UPDATE_EPOCH) {
                 return inGeneration < currentGeneration;
             }
@@ -193,7 +196,7 @@ public class SyncEventHandler {
         }
 
         if (skipFromMismatchingGeneration(inSync)) {
-            LOGGER.debug("Task {}, skipping message from task {}, from prior generation {} and message type {} with current generation {}",
+            LOGGER.info("Task {}, skipping message from task {}, from prior generation {} and message type {} with current generation {}",
                     taskSyncContextHolder.get().getTaskUid(), inSync.getTaskUid(), inSync.getRebalanceGenerationId(), inSync.getMessageType(),
                     taskSyncContextHolder.get().getRebalanceGenerationId());
             return;

--- a/src/main/java/io/debezium/connector/spanner/task/SyncEventHandler.java
+++ b/src/main/java/io/debezium/connector/spanner/task/SyncEventHandler.java
@@ -218,7 +218,8 @@ public class SyncEventHandler {
             }
         }
         catch (Exception e) {
-            LOGGER.error("Exception during processing task message task Uid {}, message type {}, {}", inSync.getTaskUid(), inSync.getMessageType(), e);
+            LOGGER.error("Exception during processing task message task Uid {}, message type {}, exception {}", inSync.getTaskUid(), inSync.getMessageType(),
+                    e.toString());
             throw e;
         }
     }

--- a/src/main/java/io/debezium/connector/spanner/task/SyncEventHandler.java
+++ b/src/main/java/io/debezium/connector/spanner/task/SyncEventHandler.java
@@ -137,22 +137,22 @@ public class SyncEventHandler {
     }
 
     public void processUpdateEpoch(TaskSyncEvent inSync, SyncEventMetadata metadata) throws InterruptedException {
-        LOGGER.info("Task {} - SyncEventHandler updating from update epoch",
+        LOGGER.debug("Task {} - SyncEventHandler updating from update epoch",
                 taskSyncContextHolder.get().getTaskUid());
         taskSyncContextHolder.update(context -> SyncEventMerger.mergeEpochUpdate(context, inSync));
 
-        LOGGER.info("Task {} - SyncEventHandler updated from update epoch",
+        LOGGER.debug("Task {} - SyncEventHandler updated from update epoch",
                 taskSyncContextHolder.get().getTaskUid());
 
         eventConsumer.accept(new SyncEvent());
     }
 
     public void processRegularMessage(TaskSyncEvent inSync, SyncEventMetadata metadata) throws InterruptedException {
-        LOGGER.info("Task {} - process regular message event", taskSyncContextHolder.get().getTaskUid());
+        LOGGER.debug("Task {} - process regular message event", taskSyncContextHolder.get().getTaskUid());
 
         taskSyncContextHolder.update(context -> SyncEventMerger.mergeIncrementalTaskSyncEvent(context, inSync));
 
-        LOGGER.info("Task {} - Finished processing regular message event", taskSyncContextHolder.get().getTaskUid());
+        LOGGER.debug("Task {} - Finished processing regular message event", taskSyncContextHolder.get().getTaskUid());
 
         eventConsumer.accept(new SyncEvent());
 
@@ -160,12 +160,12 @@ public class SyncEventHandler {
 
     public void processRebalanceAnswer(TaskSyncEvent inSync, SyncEventMetadata metadata) {
 
-        LOGGER.info("Task {} - process sync event - rebalance answer",
+        LOGGER.debug("Task {} - process sync event - rebalance answer",
                 taskSyncContextHolder.get().getTaskUid());
 
         taskSyncContextHolder.update(context -> SyncEventMerger.mergeRebalanceAnswer(context, inSync));
 
-        LOGGER.info("Task {} - process sync event - updated from rebalance answer",
+        LOGGER.debug("Task {} - process sync event - updated from rebalance answer",
                 taskSyncContextHolder.get().getTaskUid());
 
     }

--- a/src/main/java/io/debezium/connector/spanner/task/SyncEventHandler.java
+++ b/src/main/java/io/debezium/connector/spanner/task/SyncEventHandler.java
@@ -7,8 +7,6 @@ package io.debezium.connector.spanner.task;
 
 import static org.slf4j.LoggerFactory.getLogger;
 
-import java.time.Duration;
-
 import org.slf4j.Logger;
 
 import io.debezium.connector.spanner.kafka.internal.TaskSyncPublisher;
@@ -19,7 +17,6 @@ import io.debezium.connector.spanner.kafka.internal.model.TaskSyncEvent;
 import io.debezium.connector.spanner.task.state.SyncEvent;
 import io.debezium.connector.spanner.task.state.TaskStateChangeEvent;
 import io.debezium.function.BlockingConsumer;
-import io.debezium.util.Stopwatch;
 
 /**
  * Provides a logic for processing Sync Events of different types:
@@ -33,8 +30,6 @@ public class SyncEventHandler {
     private final TaskSyncPublisher taskSyncPublisher;
 
     private final BlockingConsumer<TaskStateChangeEvent> eventConsumer;
-
-    private volatile Stopwatch sw = Stopwatch.accumulating().start();
 
     public SyncEventHandler(TaskSyncContextHolder taskSyncContextHolder, TaskSyncPublisher taskSyncPublisher,
                             BlockingConsumer<TaskStateChangeEvent> eventConsumer) {
@@ -160,19 +155,6 @@ public class SyncEventHandler {
         taskSyncContextHolder.update(context -> SyncEventMerger.mergeIncrementalTaskSyncEvent(context, inSync));
 
         LOGGER.debug("Task {} - Finished processing regular message event", taskSyncContextHolder.get().getTaskUid());
-        final Duration totalDuration = sw.stop().durations().statistics().getTotal();
-        // Enqueue a new sync event every 5 seconds.
-        if (totalDuration.toMillis() >= 5000) {
-            // Restart the stopwatch.
-            LOGGER.info("Task {}, createEventHandlerThread: queueing SyncEvent",
-                    taskSyncContextHolder.get().getTaskUid());
-            eventConsumer.accept(new SyncEvent());
-            sw = Stopwatch.accumulating().start();
-        }
-        else {
-            // Resume the existing stop watch, we haven't met the criteria yet.
-            sw.start();
-        }
     }
 
     public void processRebalanceAnswer(TaskSyncEvent inSync, SyncEventMetadata metadata) {
@@ -238,8 +220,8 @@ public class SyncEventHandler {
             }
         }
         catch (Exception e) {
-            LOGGER.error("Exception during processing task message task Uid {}, message type {}, exception {}", inSync.getTaskUid(), inSync.getMessageType(),
-                    e.toString());
+            LOGGER.error("Exception during processing task message task Uid {}, message type {}, exception", inSync.getTaskUid(), inSync.getMessageType(),
+                    e);
             throw e;
         }
     }

--- a/src/main/java/io/debezium/connector/spanner/task/SyncEventMerger.java
+++ b/src/main/java/io/debezium/connector/spanner/task/SyncEventMerger.java
@@ -121,17 +121,12 @@ public class SyncEventMerger {
                             newMessage.getMessageTimestamp()));
             TaskSyncContext result = builder
                     .build();
-            LOGGER.info("Processed rebalance answer {} from task {} for rebalance generation id {}", newMessage, newMessage.getTaskUid(),
-                    newMessage.getRebalanceGenerationId());
+            LOGGER.info(
+                    "Task {}, Processed rebalance answer from task {} for rebalance generation id {}, task has total partitions {}, num partitions {}, num shared partitions {}, num old partitions {}",
+                    currentContext.getTaskUid(), newMessage.getTaskUid(),
+                    newMessage.getRebalanceGenerationId(), result.getNumPartitions() + result.getNumSharedPartitions(),
+                    result.getNumPartitions(), result.getNumSharedPartitions(), oldPartitions);
 
-            long newPartitions = result.getNumPartitions() + result.getNumSharedPartitions();
-            if (newPartitions != oldPartitions) {
-                LOGGER.info(
-                        "Task {}, processed rebalance answer {}: {}, task has total partitions {}, num partitions {}, num shared partitions {}, num old partitions {}",
-                        currentContext.getTaskUid(), newMessage, result.getNumPartitions() + result.getNumSharedPartitions(),
-                        result.getNumPartitions(), result.getNumSharedPartitions(), oldPartitions);
-
-            }
             return result;
         }
         LOGGER.debug("merge: final state is not changed");

--- a/src/main/java/io/debezium/connector/spanner/task/SyncEventMerger.java
+++ b/src/main/java/io/debezium/connector/spanner/task/SyncEventMerger.java
@@ -141,9 +141,9 @@ public class SyncEventMerger {
 
         var builder = currentContext.toBuilder();
         // do not merge if not starting initial sync / not new epoch started.
-        boolean start_initial_sync = currentContext.getRebalanceState() == RebalanceState.START_INITIAL_SYNC;
+        boolean startInitialSync = currentContext.getRebalanceState() == RebalanceState.START_INITIAL_SYNC;
 
-        if (!start_initial_sync && !currentContext.getRebalanceState().equals(RebalanceState.NEW_EPOCH_STARTED)) {
+        if (!startInitialSync && !currentContext.getRebalanceState().equals(RebalanceState.NEW_EPOCH_STARTED)) {
             return builder.build();
         }
 
@@ -247,15 +247,14 @@ public class SyncEventMerger {
         Map<String, TaskState> newTaskStates = new HashMap<>(inSync.getTaskStates());
         newTaskStates.remove(currentContext.getTaskUid());
 
-        boolean start_initial_sync = currentContext.getRebalanceState() == RebalanceState.START_INITIAL_SYNC;
-        if (!start_initial_sync) {
+        boolean startInitialSync = currentContext.getRebalanceState() == RebalanceState.START_INITIAL_SYNC;
+        if (!startInitialSync) {
             Set<String> allNewEpochTasks = inSync.getTaskStates().values().stream().map(taskState -> taskState.getTaskUid()).collect(Collectors.toSet());
             if (!allNewEpochTasks.contains(currentContext.getTaskUid())) {
                 LOGGER.warn(
                         "Task {} - Received new epoch message , but leader {} did not include the task in the new epoch message with rebalance ID {} with tasks {}, probably just initialized, throw exception",
                         currentContext.getTaskUid(), inSync.getTaskUid(), inSync.getRebalanceGenerationId(),
                         inSync.getTaskStates().keySet().stream().collect(Collectors.toList()));
-                // throw new DebeziumException("Leader did not include task in new epoch message");
             }
             else if (inSync.getRebalanceGenerationId() < currentContext.getReceivedRebalanceGenerationId()) {
                 LOGGER.warn(

--- a/src/main/java/io/debezium/connector/spanner/task/SyncEventMerger.java
+++ b/src/main/java/io/debezium/connector/spanner/task/SyncEventMerger.java
@@ -280,6 +280,9 @@ public class SyncEventMerger {
             LOGGER.info("Task {}, updating the rebalance state to NEW_EPOCH_STARTED {}: {}", currentContext.getTaskUid(), inSync.getTaskUid(),
                     inSync.getRebalanceGenerationId());
             builder.rebalanceState(RebalanceState.NEW_EPOCH_STARTED);
+            // Experimental.
+            builder.rebalanceGenerationId(inSync.getRebalanceGenerationId());
+            currentTaskBuilder.rebalanceGenerationId(inSync.getRebalanceGenerationId());
         }
 
         LOGGER.debug("Task {}, updating the epoch offset from the leader new epoch {}: {}", currentContext.getTaskUid(), inSync.getTaskUid(),

--- a/src/main/java/io/debezium/connector/spanner/task/SyncEventMerger.java
+++ b/src/main/java/io/debezium/connector/spanner/task/SyncEventMerger.java
@@ -277,6 +277,8 @@ public class SyncEventMerger {
         else {
             // Update the state to NEW_EPOCH_STARTED if we have received a new epoch message during
             // normal task execution.
+            LOGGER.info("Task {}, updating the rebalance state to NEW_EPOCH_STARTED {}: {}", currentContext.getTaskUid(), inSync.getTaskUid(),
+                    inSync.getRebalanceGenerationId());
             builder.rebalanceState(RebalanceState.NEW_EPOCH_STARTED);
         }
 
@@ -291,7 +293,7 @@ public class SyncEventMerger {
         TaskSyncContext result = builder.build();
 
         long newPartitions = result.getNumPartitions() + result.getNumSharedPartitions();
-        LOGGER.debug("Task {}, processed new epoch message {}: {}, task has total partitions {}, num partitions {}, num shared partitions {}, num old partitions {}",
+        LOGGER.info("Task {}, processed new epoch message {}: {}, task has total partitions {}, num partitions {}, num shared partitions {}, num old partitions {}",
                 currentContext.getTaskUid(), inSync.getTaskUid(),
                 inSync.getEpochOffset(), result.getNumPartitions() + result.getNumSharedPartitions(),
                 result.getNumPartitions(), result.getNumSharedPartitions(), oldPartitions);

--- a/src/main/java/io/debezium/connector/spanner/task/SyncEventMerger.java
+++ b/src/main/java/io/debezium/connector/spanner/task/SyncEventMerger.java
@@ -257,6 +257,13 @@ public class SyncEventMerger {
                         inSync.getTaskStates().keySet().stream().collect(Collectors.toList()));
                 // throw new DebeziumException("Leader did not include task in new epoch message");
             }
+            else if (inSync.getRebalanceGenerationId() < currentContext.getReceivedRebalanceGenerationId()) {
+                LOGGER.warn(
+                        "Task {} - Received new epoch message from {} , but the new epoch message had rebalance generation ID {} while the latest rebalance generation ID is {}",
+                        currentContext.getTaskUid(), inSync.getTaskUid(), inSync.getRebalanceGenerationId(),
+                        currentContext.getReceivedRebalanceGenerationId());
+
+            }
             else {
                 LOGGER.info("Task {}, updating the rebalance state to NEW_EPOCH_STARTED {}: {}", currentContext.getTaskUid(), inSync.getTaskUid(),
                         inSync.getRebalanceGenerationId());

--- a/src/main/java/io/debezium/connector/spanner/task/SyncEventMerger.java
+++ b/src/main/java/io/debezium/connector/spanner/task/SyncEventMerger.java
@@ -18,7 +18,6 @@ import java.util.stream.Stream;
 
 import org.slf4j.Logger;
 
-import io.debezium.DebeziumException;
 import io.debezium.connector.spanner.kafka.internal.model.RebalanceState;
 import io.debezium.connector.spanner.kafka.internal.model.TaskState;
 import io.debezium.connector.spanner.kafka.internal.model.TaskSyncEvent;
@@ -256,7 +255,7 @@ public class SyncEventMerger {
                         "Task {} - Received new epoch message , but leader {} did not include the task in the new epoch message with rebalance ID {} with tasks {}, probably just initialized, throw exception",
                         currentContext.getTaskUid(), inSync.getTaskUid(), inSync.getRebalanceGenerationId(),
                         inSync.getTaskStates().keySet().stream().collect(Collectors.toList()));
-                throw new DebeziumException("Leader did not include task in new epoch message");
+                // throw new DebeziumException("Leader did not include task in new epoch message");
             }
             else {
                 LOGGER.info("Task {}, updating the rebalance state to NEW_EPOCH_STARTED {}: {}", currentContext.getTaskUid(), inSync.getTaskUid(),

--- a/src/main/java/io/debezium/connector/spanner/task/SynchronizationTaskContext.java
+++ b/src/main/java/io/debezium/connector/spanner/task/SynchronizationTaskContext.java
@@ -237,7 +237,6 @@ public class SynchronizationTaskContext {
     public void publishEvent(TaskStateChangeEvent event) throws InterruptedException {
         LoggerUtils.debug(LOGGER, "publishEvent: type: {}, event: {}", event.getClass().getSimpleName(), event);
 
-        LOGGER.info("Task {}, publishing event: {}", this.taskSyncContextHolder.get().getTaskUid(), (event.getClass()) event);
         this.taskStateChangeEventProcessor.processEvent(event);
     }
 

--- a/src/main/java/io/debezium/connector/spanner/task/SynchronizationTaskContext.java
+++ b/src/main/java/io/debezium/connector/spanner/task/SynchronizationTaskContext.java
@@ -114,6 +114,7 @@ public class SynchronizationTaskContext {
         this.taskSyncContextHolder = new TaskSyncContextHolder(metricsEventPublisher);
 
         this.taskSyncPublisher = new TaskSyncPublisher(task.getTaskUid(), taskSyncTopic, connectorConfig.syncEventPublisherWaitingTimeout(), producerFactory,
+                taskSyncContextHolder,
                 this::onError);
 
         final KafkaConsumerAdminService kafkaAdminService = new KafkaConsumerAdminService(adminClientFactory.getAdminClient(), connectorName);

--- a/src/main/java/io/debezium/connector/spanner/task/SynchronizationTaskContext.java
+++ b/src/main/java/io/debezium/connector/spanner/task/SynchronizationTaskContext.java
@@ -242,6 +242,11 @@ public class SynchronizationTaskContext {
     }
 
     private void onError(Throwable throwable) {
+        if (this.rebalancingEventListener != null) {
+            LOGGER.info("Task {}, shutting down rebalancing event listener due to error in task", this.taskSyncContextHolder.get().getTaskUid(), throwable);
+            this.rebalancingEventListener.shutdown();
+        }
+        LOGGER.info("Task {}, enqueueing error in task", this.taskSyncContextHolder.get().getTaskUid(), throwable);
         this.errorHandler.setProducerThrowable(throwable);
     }
 

--- a/src/main/java/io/debezium/connector/spanner/task/SynchronizationTaskContext.java
+++ b/src/main/java/io/debezium/connector/spanner/task/SynchronizationTaskContext.java
@@ -203,10 +203,11 @@ public class SynchronizationTaskContext {
     public synchronized void destroy() {
 
         try {
-            this.taskSyncEventListener.shutdown();
-            LOGGER.info("Task {}, Shut down TaskSyncEventListener", this.taskSyncContextHolder.get().getTaskUid());
             this.rebalancingEventListener.shutdown();
             LOGGER.info("Task {}, Shut down rebalancingEventListener", this.taskSyncContextHolder.get().getTaskUid());
+
+            this.taskSyncEventListener.shutdown();
+            LOGGER.info("Task {}, Shut down TaskSyncEventListener", this.taskSyncContextHolder.get().getTaskUid());
 
             this.taskStateChangeEventProcessor.stopProcessing();
             LOGGER.info("Task {}, Shut down TaskStateChangeEventProcessor", this.taskSyncContextHolder.get().getTaskUid());

--- a/src/main/java/io/debezium/connector/spanner/task/SynchronizationTaskContext.java
+++ b/src/main/java/io/debezium/connector/spanner/task/SynchronizationTaskContext.java
@@ -155,7 +155,7 @@ public class SynchronizationTaskContext {
         final LowWatermarkCalculator lowWatermarkCalculator = new LowWatermarkCalculator(connectorConfig, taskSyncContextHolder, partitionOffsetProvider);
 
         this.lowWatermarkCalculationJob = new LowWatermarkCalculationJob(connectorConfig, this::onError, lowWatermarkCalculator,
-                lowWatermarkHolder);
+                lowWatermarkHolder, task.getTaskUid());
 
         this.taskStateChangeEventProcessor = new TaskStateChangeEventProcessor(connectorConfig.taskStateChangeEventQueueCapacity(),
                 taskSyncContextHolder, taskStateChangeEventHandler, this::onError, metricsEventPublisher);

--- a/src/main/java/io/debezium/connector/spanner/task/SynchronizationTaskContext.java
+++ b/src/main/java/io/debezium/connector/spanner/task/SynchronizationTaskContext.java
@@ -237,7 +237,7 @@ public class SynchronizationTaskContext {
     public void publishEvent(TaskStateChangeEvent event) throws InterruptedException {
         LoggerUtils.debug(LOGGER, "publishEvent: type: {}, event: {}", event.getClass().getSimpleName(), event);
 
-        LOGGER.info("Task {}, publishing event: {}", this.taskSyncContextHolder.get().getTaskUid(), event);
+        LOGGER.info("Task {}, publishing event: {}", this.taskSyncContextHolder.get().getTaskUid(), (event.getClass()) event);
         this.taskStateChangeEventProcessor.processEvent(event);
     }
 

--- a/src/main/java/io/debezium/connector/spanner/task/SynchronizationTaskContext.java
+++ b/src/main/java/io/debezium/connector/spanner/task/SynchronizationTaskContext.java
@@ -206,17 +206,17 @@ public class SynchronizationTaskContext {
         }
     }
 
-    public synchronized void destroy() {
+    public void destroy() {
 
         try {
+            this.rebalancingEventListener.shutdown();
+            LOGGER.info("Task {}, Shut down rebalancingEventListener", this.taskSyncContextHolder.get().getTaskUid());
+
             this.taskSyncEventListener.shutdown();
             LOGGER.info("Task {}, Shut down TaskSyncEventListener", this.taskSyncContextHolder.get().getTaskUid());
 
             this.taskSyncPublisher.close();
             LOGGER.info("Task {}, Shut down TaskSyncPublisher", this.taskSyncContextHolder.get().getTaskUid());
-
-            this.rebalancingEventListener.shutdown();
-            LOGGER.info("Task {}, Shut down rebalancingEventListener", this.taskSyncContextHolder.get().getTaskUid());
 
             this.taskStateChangeEventProcessor.stopProcessing();
             LOGGER.info("Task {}, Shut down TaskStateChangeEventProcessor", this.taskSyncContextHolder.get().getTaskUid());

--- a/src/main/java/io/debezium/connector/spanner/task/SynchronizationTaskContext.java
+++ b/src/main/java/io/debezium/connector/spanner/task/SynchronizationTaskContext.java
@@ -211,10 +211,10 @@ public class SynchronizationTaskContext {
         try {
             this.taskSyncEventListener.shutdown();
             LOGGER.info("Task {}, Shut down TaskSyncEventListener", this.taskSyncContextHolder.get().getTaskUid());
-          
+
             this.taskSyncPublisher.close();
             LOGGER.info("Task {}, Shut down TaskSyncPublisher", this.taskSyncContextHolder.get().getTaskUid());
-          
+
             this.rebalancingEventListener.shutdown();
             LOGGER.info("Task {}, Shut down rebalancingEventListener", this.taskSyncContextHolder.get().getTaskUid());
 
@@ -226,7 +226,7 @@ public class SynchronizationTaskContext {
 
             this.rebalanceHandler.destroy();
             LOGGER.info("Task {}, Shut down rebalance handler", this.taskSyncContextHolder.get().getTaskUid());
-    
+
         }
         catch (Throwable ex) {
             LOGGER.warn("Task {}, Exception during sync context destroying", this.taskSyncContextHolder.get().getTaskUid(), ex);
@@ -237,6 +237,7 @@ public class SynchronizationTaskContext {
     public void publishEvent(TaskStateChangeEvent event) throws InterruptedException {
         LoggerUtils.debug(LOGGER, "publishEvent: type: {}, event: {}", event.getClass().getSimpleName(), event);
 
+        LOGGER.info("Task {}, publishing event: {}", this.taskSyncContextHolder.get().getTaskUid(), event);
         this.taskStateChangeEventProcessor.processEvent(event);
     }
 

--- a/src/main/java/io/debezium/connector/spanner/task/SynchronizedPartitionManager.java
+++ b/src/main/java/io/debezium/connector/spanner/task/SynchronizedPartitionManager.java
@@ -39,6 +39,7 @@ public class SynchronizedPartitionManager implements PartitionManager {
 
     @Override
     public void updateToFinished(String token) throws InterruptedException {
+        LOGGER.info("Token {}, updating to finished");
 
         syncEventPublisher.accept(new PartitionStatusUpdateEvent(token, PartitionStateEnum.FINISHED));
     }

--- a/src/main/java/io/debezium/connector/spanner/task/SynchronizedPartitionManager.java
+++ b/src/main/java/io/debezium/connector/spanner/task/SynchronizedPartitionManager.java
@@ -39,8 +39,6 @@ public class SynchronizedPartitionManager implements PartitionManager {
 
     @Override
     public void updateToFinished(String token) throws InterruptedException {
-        LOGGER.info("Token {}, updating to finished");
-
         syncEventPublisher.accept(new PartitionStatusUpdateEvent(token, PartitionStateEnum.FINISHED));
     }
 

--- a/src/main/java/io/debezium/connector/spanner/task/TaskStateChangeEventHandler.java
+++ b/src/main/java/io/debezium/connector/spanner/task/TaskStateChangeEventHandler.java
@@ -155,8 +155,6 @@ public class TaskStateChangeEventHandler {
         TaskSyncContext taskSyncContext = taskSyncContextHolder.updateAndGet(context -> {
             TaskSyncContext newContext = context;
             for (Operation operation : operations) {
-                LOGGER.info("Task {} - doing operation {} out of {} operations",
-                        taskSyncContextHolder.get().getTaskUid(), operation.getClass().getSimpleName(), operations.length);
                 newContext = operation.doOperation(newContext);
                 if (operation.isRequiredPublishSyncEvent()) {
                     LOGGER.debug("Task {} - need to publish sync event for operation {}",

--- a/src/main/java/io/debezium/connector/spanner/task/TaskStateChangeEventHandler.java
+++ b/src/main/java/io/debezium/connector/spanner/task/TaskStateChangeEventHandler.java
@@ -155,6 +155,8 @@ public class TaskStateChangeEventHandler {
         TaskSyncContext taskSyncContext = taskSyncContextHolder.updateAndGet(context -> {
             TaskSyncContext newContext = context;
             for (Operation operation : operations) {
+                LOGGER.debug("Task {} - doing operation {} out of {} operations",
+                        taskSyncContextHolder.get().getTaskUid(), operation.getClass().getSimpleName(), operations.length);
                 newContext = operation.doOperation(newContext);
                 if (operation.isRequiredPublishSyncEvent()) {
                     LOGGER.debug("Task {} - need to publish sync event for operation {}",

--- a/src/main/java/io/debezium/connector/spanner/task/TaskStateChangeEventHandler.java
+++ b/src/main/java/io/debezium/connector/spanner/task/TaskStateChangeEventHandler.java
@@ -93,7 +93,7 @@ public class TaskStateChangeEventHandler {
             throw new IllegalStateException("Unknown event");
         }
         long thenMillis = Instant.now().toEpochMilli();
-        LOGGER.info(
+        LOGGER.debug(
                 "Task {}, TaskStateChangeEventHandler: Processed {} in {} millis",
                 taskSyncContextHolder.get().getTaskUid(), syncEvent.getClass().getSimpleName(), thenMillis - nowMillis);
 
@@ -171,7 +171,7 @@ public class TaskStateChangeEventHandler {
                     publishTaskSyncEvent.set(true);
                 }
                 long thenMillis = Instant.now().toEpochMilli();
-                LOGGER.info("Task {} - did operation {} in {} millis",
+                LOGGER.debug("Task {} - did operation {} in {} millis",
                         taskSyncContextHolder.get().getTaskUid(), operation.getClass().getSimpleName(), thenMillis - nowMillis);
             }
             return newContext;

--- a/src/main/java/io/debezium/connector/spanner/task/TaskStateChangeEventHandler.java
+++ b/src/main/java/io/debezium/connector/spanner/task/TaskStateChangeEventHandler.java
@@ -102,6 +102,7 @@ public class TaskStateChangeEventHandler {
     private void processEvent(PartitionStatusUpdateEvent event) throws InterruptedException {
         performOperation(
                 new PartitionStatusUpdateOperation(event.getToken(), event.getState()),
+                new ClearSharedPartitionOperation(),
                 new FindPartitionForStreamingOperation(),
                 new TakePartitionForStreamingOperation(changeStream, partitionFactory));
     }
@@ -109,8 +110,10 @@ public class TaskStateChangeEventHandler {
     private void processEvent(NewPartitionsEvent newPartitionsEvent) throws InterruptedException {
         performOperation(
                 new ChildPartitionOperation(newPartitionsEvent.getPartitions()),
+                new ClearSharedPartitionOperation(),
                 new FindPartitionForStreamingOperation(),
-                new TakePartitionForStreamingOperation(changeStream, partitionFactory));
+                new TakePartitionForStreamingOperation(changeStream, partitionFactory),
+                new RemoveFinishedPartitionOperation(spannerEventDispatcher, connectorConfig));
     }
 
     private void processSyncEvent() throws InterruptedException {

--- a/src/main/java/io/debezium/connector/spanner/task/TaskStateChangeEventHandler.java
+++ b/src/main/java/io/debezium/connector/spanner/task/TaskStateChangeEventHandler.java
@@ -154,14 +154,20 @@ public class TaskStateChangeEventHandler {
 
         TaskSyncContext taskSyncContext = taskSyncContextHolder.updateAndGet(context -> {
             TaskSyncContext newContext = context;
+            int i = 0;
             for (Operation operation : operations) {
+                i++;
+                LOGGER.info("Task {} - performing operation on {} out of {} operations",
+                        taskSyncContextHolder.get().getTaskUid(), operation.getClass().getSimpleName(), i, operations.length);
                 newContext = operation.doOperation(newContext);
                 if (operation.isRequiredPublishSyncEvent()) {
-                    LOGGER.debug("Task {} - need to publish sync event for operation {}",
+                    LOGGER.info("Task {} - need to publish sync event for operation {}",
                             taskSyncContextHolder.get().getTaskUid(), operation.getClass().getSimpleName());
                     publishTaskSyncEvent.set(true);
                 }
             }
+            LOGGER.info("Task {} - done performing operations on operations",
+                    taskSyncContextHolder.get().getTaskUid());
             return newContext;
         });
 

--- a/src/main/java/io/debezium/connector/spanner/task/TaskStateChangeEventHandler.java
+++ b/src/main/java/io/debezium/connector/spanner/task/TaskStateChangeEventHandler.java
@@ -154,20 +154,14 @@ public class TaskStateChangeEventHandler {
 
         TaskSyncContext taskSyncContext = taskSyncContextHolder.updateAndGet(context -> {
             TaskSyncContext newContext = context;
-            int i = 0;
             for (Operation operation : operations) {
-                i++;
-                LOGGER.info("Task {} - performing operation on {} out of {} operations",
-                        taskSyncContextHolder.get().getTaskUid(), operation.getClass().getSimpleName(), i, operations.length);
                 newContext = operation.doOperation(newContext);
                 if (operation.isRequiredPublishSyncEvent()) {
-                    LOGGER.info("Task {} - need to publish sync event for operation {}",
+                    LOGGER.debug("Task {} - need to publish sync event for operation {}",
                             taskSyncContextHolder.get().getTaskUid(), operation.getClass().getSimpleName());
                     publishTaskSyncEvent.set(true);
                 }
             }
-            LOGGER.info("Task {} - done performing operations on operations",
-                    taskSyncContextHolder.get().getTaskUid());
             return newContext;
         });
 

--- a/src/main/java/io/debezium/connector/spanner/task/TaskStateChangeEventHandler.java
+++ b/src/main/java/io/debezium/connector/spanner/task/TaskStateChangeEventHandler.java
@@ -155,7 +155,7 @@ public class TaskStateChangeEventHandler {
         TaskSyncContext taskSyncContext = taskSyncContextHolder.updateAndGet(context -> {
             TaskSyncContext newContext = context;
             for (Operation operation : operations) {
-                LOGGER.debug("Task {} - doing operation {} out of {} operations",
+                LOGGER.info("Task {} - doing operation {} out of {} operations",
                         taskSyncContextHolder.get().getTaskUid(), operation.getClass().getSimpleName(), operations.length);
                 newContext = operation.doOperation(newContext);
                 if (operation.isRequiredPublishSyncEvent()) {

--- a/src/main/java/io/debezium/connector/spanner/task/TaskStateChangeEventHandler.java
+++ b/src/main/java/io/debezium/connector/spanner/task/TaskStateChangeEventHandler.java
@@ -93,7 +93,7 @@ public class TaskStateChangeEventHandler {
             throw new IllegalStateException("Unknown event");
         }
         long thenMillis = Instant.now().toEpochMilli();
-        LOGGER.debug(
+        LOGGER.info(
                 "Task {}, TaskStateChangeEventHandler: Processed {} in {} millis",
                 taskSyncContextHolder.get().getTaskUid(), syncEvent.getClass().getSimpleName(), thenMillis - nowMillis);
 
@@ -168,7 +168,7 @@ public class TaskStateChangeEventHandler {
                     publishTaskSyncEvent.set(true);
                 }
                 long thenMillis = Instant.now().toEpochMilli();
-                LOGGER.debug("Task {} - did operation {} in {} millis",
+                LOGGER.info("Task {} - did operation {} in {} millis",
                         taskSyncContextHolder.get().getTaskUid(), operation.getClass().getSimpleName(), thenMillis - nowMillis);
             }
             return newContext;

--- a/src/main/java/io/debezium/connector/spanner/task/TaskStateChangeEventProcessor.java
+++ b/src/main/java/io/debezium/connector/spanner/task/TaskStateChangeEventProcessor.java
@@ -82,7 +82,7 @@ public class TaskStateChangeEventProcessor {
                     return;
                 }
                 catch (Exception e) {
-                    LOGGER.error("Task caught exception from event queueing thread");
+                    LOGGER.error("Task caught exception from event queueing thread", e);
                 }
             }
         });

--- a/src/main/java/io/debezium/connector/spanner/task/TaskStateChangeEventProcessor.java
+++ b/src/main/java/io/debezium/connector/spanner/task/TaskStateChangeEventProcessor.java
@@ -76,8 +76,8 @@ public class TaskStateChangeEventProcessor {
 
                 taskSyncContextHolder.awaitNewEpoch();
 
-                this.taskSyncContextHolder.lock();
                 try {
+                    this.taskSyncContextHolder.lock();
                     this.taskStateChangeEventHandler.processEvent(event);
                 }
                 catch (InterruptedException e) {

--- a/src/main/java/io/debezium/connector/spanner/task/TaskStateChangeEventProcessor.java
+++ b/src/main/java/io/debezium/connector/spanner/task/TaskStateChangeEventProcessor.java
@@ -61,12 +61,11 @@ public class TaskStateChangeEventProcessor {
                 TaskStateChangeEvent event;
                 try {
                     LOGGER.debug("createEventHandlerThread: Wait for sync event");
+
                     event = this.queue.take();
 
                     metricsEventPublisher.publishMetricEvent(new TaskStateChangeQueueUpdateMetricEvent(queue.remainingCapacity()));
 
-                    LoggerUtils.debug(LOGGER, "createEventHandlerThread: Received sync event of type: {}, event: {}",
-                            event.getClass().getSimpleName(), event);
                 }
                 catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
@@ -120,6 +119,7 @@ public class TaskStateChangeEventProcessor {
         else {
             queue.put(event);
         }
+
         metricsEventPublisher.publishMetricEvent(new TaskStateChangeQueueUpdateMetricEvent(queue.remainingCapacity()));
     }
 

--- a/src/main/java/io/debezium/connector/spanner/task/TaskStateChangeEventProcessor.java
+++ b/src/main/java/io/debezium/connector/spanner/task/TaskStateChangeEventProcessor.java
@@ -77,15 +77,11 @@ public class TaskStateChangeEventProcessor {
                 taskSyncContextHolder.awaitNewEpoch();
 
                 try {
-                    this.taskSyncContextHolder.lock();
                     this.taskStateChangeEventHandler.processEvent(event);
                 }
                 catch (InterruptedException e) {
                     LOGGER.info("Task {}, interrupting the event handler thread", this.taskSyncContextHolder.get().getTaskUid());
                     Thread.currentThread().interrupt();
-                }
-                finally {
-                    this.taskSyncContextHolder.unlock();
                 }
             }
         }, "SpannerConnector-TaskStateChangeEventProcessor");

--- a/src/main/java/io/debezium/connector/spanner/task/TaskStateChangeEventProcessor.java
+++ b/src/main/java/io/debezium/connector/spanner/task/TaskStateChangeEventProcessor.java
@@ -146,9 +146,9 @@ public class TaskStateChangeEventProcessor {
                 try {
 
                     LOGGER.info("Task {}, still waiting for event queueing thread to die", this.taskSyncContextHolder.get().getTaskUid());
-                   
+
                     this.eventQueueingThread.interrupt();
-                  
+
                     // Sleep for sleepInterval.
                     metronome.pause();
                 }

--- a/src/main/java/io/debezium/connector/spanner/task/TaskStateChangeEventProcessor.java
+++ b/src/main/java/io/debezium/connector/spanner/task/TaskStateChangeEventProcessor.java
@@ -71,7 +71,7 @@ public class TaskStateChangeEventProcessor {
                     if (taskSyncContextHolder.get() == null) {
                         continue;
                     }
-                    LOGGER.info("Task {}, continuing Event Queueing Thread",
+                    LOGGER.debug("Task {}, continuing Event Queueing Thread",
                             taskSyncContextHolder.get().getTaskUid());
                     this.queue.put(new SyncEvent());
                     metronome.pause();

--- a/src/main/java/io/debezium/connector/spanner/task/TaskSyncContext.java
+++ b/src/main/java/io/debezium/connector/spanner/task/TaskSyncContext.java
@@ -57,16 +57,20 @@ public class TaskSyncContext {
         Map<String, TaskState> taskStateMap = new HashMap<>(this.taskStates);
         taskStateMap.put(currentTaskState.getTaskUid(), currentTaskState.toBuilder()
                 .consumerId(consumerId)
-                .rebalanceGenerationId(rebalanceGenerationId)
+                .rebalanceGenerationId(this.getRebalanceGenerationId())
                 .stateTimestamp(Instant.now().toEpochMilli()).build());
         return Map.copyOf(taskStateMap);
     }
 
     public Map<String, TaskState> getCurrentTaskStateMap() {
+        return getCurrentTaskStateMapWithRebalanceGenerationId(this.getRebalanceGenerationId());
+    }
+
+    public Map<String, TaskState> getCurrentTaskStateMapWithRebalanceGenerationId(long inputRebalanceGenerationId) {
         Map<String, TaskState> currentTaskStateMap = new HashMap<>();
         currentTaskStateMap.put(currentTaskState.getTaskUid(), currentTaskState.toBuilder()
                 .consumerId(consumerId)
-                .rebalanceGenerationId(rebalanceGenerationId)
+                .rebalanceGenerationId(inputRebalanceGenerationId)
                 .stateTimestamp(Instant.now().toEpochMilli()).build());
         return Map.copyOf(currentTaskStateMap);
     }
@@ -98,12 +102,12 @@ public class TaskSyncContext {
     }
 
     // Builds a rebalance answer task sync event, which will contain only the current task state.
-    public TaskSyncEvent buildRebalanceAnswerTaskSyncEvent() {
+    public TaskSyncEvent buildRebalanceAnswerTaskSyncEvent(long inputRebalanceGenerationId) {
         return TaskSyncEvent.builder().epochOffset(this.epochOffsetHolder.getEpochOffset()).taskStates(
-                this.getCurrentTaskStateMap())
+                this.getCurrentTaskStateMapWithRebalanceGenerationId(inputRebalanceGenerationId))
                 .taskUid(this.getTaskUid())
                 .consumerId(this.getConsumerId())
-                .rebalanceGenerationId(this.getRebalanceGenerationId())
+                .rebalanceGenerationId(inputRebalanceGenerationId)
                 .messageTimestamp(this.getCreatedTimestamp())
                 .messageType(MessageTypeEnum.REBALANCE_ANSWER)
                 .databaseSchemaTimestamp(databaseSchemaTimestamp)

--- a/src/main/java/io/debezium/connector/spanner/task/TaskSyncContext.java
+++ b/src/main/java/io/debezium/connector/spanner/task/TaskSyncContext.java
@@ -40,6 +40,7 @@ public class TaskSyncContext {
     private final RebalanceState rebalanceState;
     private final String consumerId;
     private final long rebalanceGenerationId;
+    private final long receivedRebalanceGenerationId;
     private final EpochOffsetHolder epochOffsetHolder;
     private final long currentKafkaRecordOffset;
     private final boolean isLeader;
@@ -133,6 +134,7 @@ public class TaskSyncContext {
                 .consumerId("")
                 .databaseSchemaTimestamp(connectorConfig.startTime())
                 .rebalanceGenerationId(-2)
+                .receivedRebalanceGenerationId(-2)
                 .rebalanceState(RebalanceState.START_INITIAL_SYNC)
                 .createdTimestamp(now)
                 .currentTaskState(
@@ -166,6 +168,7 @@ public class TaskSyncContext {
                     final RebalanceState rebalanceState,
                     final String consumerId,
                     final long rebalanceGenerationId,
+                    final long receivedRebalanceGenerationId,
                     final EpochOffsetHolder epochOffsetHolder,
                     final long currentKafkaRecordOffset,
                     final boolean isLeader,
@@ -179,6 +182,7 @@ public class TaskSyncContext {
         this.rebalanceState = rebalanceState;
         this.consumerId = consumerId;
         this.rebalanceGenerationId = rebalanceGenerationId;
+        this.receivedRebalanceGenerationId = receivedRebalanceGenerationId;
         this.epochOffsetHolder = epochOffsetHolder;
         this.currentKafkaRecordOffset = currentKafkaRecordOffset;
         this.isLeader = isLeader;
@@ -195,6 +199,7 @@ public class TaskSyncContext {
         private RebalanceState rebalanceState;
         private String consumerId;
         private long rebalanceGenerationId;
+        private long receivedRebalanceGenerationId;
         private boolean epochOffsetHolderSet;
         private EpochOffsetHolder epochOffsetHolderValue;
         private long currentKafkaRecordOffset;
@@ -232,6 +237,11 @@ public class TaskSyncContext {
 
         public TaskSyncContext.TaskSyncContextBuilder rebalanceGenerationId(final long rebalanceGenerationId) {
             this.rebalanceGenerationId = rebalanceGenerationId;
+            return this;
+        }
+
+        public TaskSyncContext.TaskSyncContextBuilder receivedRebalanceGenerationId(final long receivedRebalanceGenerationId) {
+            this.receivedRebalanceGenerationId = receivedRebalanceGenerationId;
             return this;
         }
 
@@ -306,7 +316,7 @@ public class TaskSyncContext {
             }
 
             return new TaskSyncContext(this.taskUid, this.rebalanceState, this.consumerId,
-                    this.rebalanceGenerationId, epochOffsetHolderValue,
+                    this.rebalanceGenerationId, this.receivedRebalanceGenerationId, epochOffsetHolderValue,
                     this.currentKafkaRecordOffset, isLeaderValue, createdTimestampValue,
                     taskStatesValue, this.currentTaskState, databaseSchemaTimestamp, finished, initialized);
         }
@@ -336,6 +346,7 @@ public class TaskSyncContext {
                 .rebalanceState(this.rebalanceState)
                 .consumerId(this.consumerId)
                 .rebalanceGenerationId(this.rebalanceGenerationId)
+                .receivedRebalanceGenerationId(this.receivedRebalanceGenerationId)
                 .epochOffsetHolder(this.epochOffsetHolder)
                 .currentKafkaRecordOffset(this.currentKafkaRecordOffset)
                 .isLeader(this.isLeader)
@@ -361,6 +372,10 @@ public class TaskSyncContext {
 
     public long getRebalanceGenerationId() {
         return this.rebalanceGenerationId;
+    }
+
+    public long getReceivedRebalanceGenerationId() {
+        return this.receivedRebalanceGenerationId;
     }
 
     public EpochOffsetHolder getEpochOffsetHolder() {

--- a/src/main/java/io/debezium/connector/spanner/task/TaskSyncContextHolder.java
+++ b/src/main/java/io/debezium/connector/spanner/task/TaskSyncContextHolder.java
@@ -63,18 +63,10 @@ public class TaskSyncContextHolder {
     public TaskSyncContext updateAndGet(UnaryOperator<TaskSyncContext> updateFunction) {
         TaskSyncContext taskSyncContext;
         try {
-            LOGGER.info("Task {}, locking,  lock debug string {}, hold count {}, thread name {}", get().getTaskUid(), lockDebugString(), lock.getHoldCount(),
-                    Thread.currentThread().getName());
             lock.lock();
-            LOGGER.info("Task {}, finished locking,  lock debug string {}, hold count {}, thread name {}", get().getTaskUid(), lockDebugString(), lock.getHoldCount(),
-                    Thread.currentThread().getName());
             taskSyncContext = taskSyncContextRef.updateAndGet(updateFunction);
-            LOGGER.info("Task {}, finished updating,  lock debug string {}, hold count {}, thread name {}", get().getTaskUid(), lockDebugString(), lock.getHoldCount(),
-                    Thread.currentThread().getName());
         }
         finally {
-            LOGGER.info("Task {}, trying to unlock,  lock debug string {}, hold count {}, thread name {}", get().getTaskUid(), lockDebugString(), lock.getHoldCount(),
-                    Thread.currentThread().getName());
             if (lock.isHeldByCurrentThread()) {
                 lock.unlock();
             }

--- a/src/main/java/io/debezium/connector/spanner/task/TaskSyncContextHolder.java
+++ b/src/main/java/io/debezium/connector/spanner/task/TaskSyncContextHolder.java
@@ -66,7 +66,11 @@ public class TaskSyncContextHolder {
             LOGGER.info("Task {}, locking,  lock debug string {}, hold count {}, thread name {}", get().getTaskUid(), lockDebugString(), lock.getHoldCount(),
                     Thread.currentThread().getName());
             lock.lock();
+            LOGGER.info("Task {}, finished locking,  lock debug string {}, hold count {}, thread name {}", get().getTaskUid(), lockDebugString(), lock.getHoldCount(),
+                    Thread.currentThread().getName());
             taskSyncContext = taskSyncContextRef.updateAndGet(updateFunction);
+            LOGGER.info("Task {}, finished updating,  lock debug string {}, hold count {}, thread name {}", get().getTaskUid(), lockDebugString(), lock.getHoldCount(),
+                    Thread.currentThread().getName());
         }
         finally {
             LOGGER.info("Task {}, trying to unlock,  lock debug string {}, hold count {}, thread name {}", get().getTaskUid(), lockDebugString(), lock.getHoldCount(),

--- a/src/main/java/io/debezium/connector/spanner/task/TaskSyncContextHolder.java
+++ b/src/main/java/io/debezium/connector/spanner/task/TaskSyncContextHolder.java
@@ -51,6 +51,26 @@ public class TaskSyncContextHolder {
         return taskSyncContextRef.get();
     }
 
+    public boolean isLocked() {
+        return lock.isLocked();
+    }
+
+    public boolean isLockedByCurrentThread() {
+        return lock.isHeldByCurrentThread();
+    }
+
+    public String lockDebugString() {
+        return lock.toString();
+    }
+
+    public int getQueueLength() {
+        return lock.getQueueLength();
+    }
+
+    public int getHoldCount() {
+        return lock.getHoldCount();
+    }
+
     public void update(UnaryOperator<TaskSyncContext> updateFunction) {
         this.updateAndGet(updateFunction);
     }

--- a/src/main/java/io/debezium/connector/spanner/task/TaskSyncContextHolder.java
+++ b/src/main/java/io/debezium/connector/spanner/task/TaskSyncContextHolder.java
@@ -103,6 +103,7 @@ public class TaskSyncContextHolder {
                 Thread.currentThread().interrupt();
             }
         }
+
     }
 
 }

--- a/src/main/java/io/debezium/connector/spanner/task/TaskSyncContextHolder.java
+++ b/src/main/java/io/debezium/connector/spanner/task/TaskSyncContextHolder.java
@@ -62,19 +62,17 @@ public class TaskSyncContextHolder {
 
     public TaskSyncContext updateAndGet(UnaryOperator<TaskSyncContext> updateFunction) {
         TaskSyncContext taskSyncContext;
+        LOGGER.info("Task {}, trying to lock TaskSyncContext, lock debug string {}", get().getTaskUid(), lockDebugString());
+        lock.lock();
+        LOGGER.info("Task {}, locked TaskSyncContext, lock debug string {}", get().getTaskUid(), lockDebugString());
         try {
-            LOGGER.info("Task {}, trying to lock TaskSyncContext, lock debug string {}", get().getTaskUid(), lockDebugString());
-            lock.lock();
-            LOGGER.info("Task {}, locked TaskSyncContext, lock debug string {}", get().getTaskUid(), lockDebugString());
             taskSyncContext = taskSyncContextRef.updateAndGet(updateFunction);
             LOGGER.info("Task {}, updated TaskSyncContext, lock debug string {}", get().getTaskUid(), lockDebugString());
         }
         finally {
-            if (lock.isHeldByCurrentThread()) {
-                LOGGER.info("Task {}, unlocking TaskSyncContext, lock debug string {}", get().getTaskUid(), lockDebugString());
-                lock.unlock();
-                LOGGER.info("Task {}, unlocked TaskSyncContext, lock debug string {}", get().getTaskUid(), lockDebugString());
-            }
+            LOGGER.info("Task {}, unlocking TaskSyncContext, lock debug string {}", get().getTaskUid(), lockDebugString());
+            lock.unlock();
+            LOGGER.info("Task {}, unlocked TaskSyncContext, lock debug string {}", get().getTaskUid(), lockDebugString());
         }
 
         metricsEventPublisher.publishMetricEvent(new TaskSyncContextMetricEvent(taskSyncContext));

--- a/src/main/java/io/debezium/connector/spanner/task/TaskSyncContextHolder.java
+++ b/src/main/java/io/debezium/connector/spanner/task/TaskSyncContextHolder.java
@@ -63,10 +63,14 @@ public class TaskSyncContextHolder {
     public TaskSyncContext updateAndGet(UnaryOperator<TaskSyncContext> updateFunction) {
         TaskSyncContext taskSyncContext;
         try {
+            LOGGER.info("Task {}, locking,  lock debug string {}, hold count {}, thread name {}", get().getTaskUid(), lockDebugString(), lock.getHoldCount(),
+                    Thread.currentThread().getName());
             lock.lock();
             taskSyncContext = taskSyncContextRef.updateAndGet(updateFunction);
         }
         finally {
+            LOGGER.info("Task {}, trying to unlock,  lock debug string {}, hold count {}, thread name {}", get().getTaskUid(), lockDebugString(), lock.getHoldCount(),
+                    Thread.currentThread().getName());
             if (lock.isHeldByCurrentThread()) {
                 lock.unlock();
             }
@@ -75,16 +79,6 @@ public class TaskSyncContextHolder {
         metricsEventPublisher.publishMetricEvent(new TaskSyncContextMetricEvent(taskSyncContext));
 
         return taskSyncContext;
-    }
-
-    public void lock() {
-        lock.lock();
-    }
-
-    public void unlock() {
-        if (lock.isHeldByCurrentThread()) {
-            lock.unlock();
-        }
     }
 
     public void awaitInitialization(Duration awaitTimeout) {

--- a/src/main/java/io/debezium/connector/spanner/task/leader/LeaderAction.java
+++ b/src/main/java/io/debezium/connector/spanner/task/leader/LeaderAction.java
@@ -75,7 +75,6 @@ public class LeaderAction {
         this.taskSyncPublisher = taskSyncPublisher;
         this.errorHandler = errorHandler;
         this.clock = Clock.system();
-
     }
 
     private Thread createLeaderThread() {
@@ -148,7 +147,7 @@ public class LeaderAction {
         this.leaderThread.start();
     }
 
-    public synchronized void stop() {
+    public void stop() {
         if (this.leaderThread == null) {
             return;
         }

--- a/src/main/java/io/debezium/connector/spanner/task/leader/LeaderAction.java
+++ b/src/main/java/io/debezium/connector/spanner/task/leader/LeaderAction.java
@@ -46,7 +46,7 @@ public class LeaderAction {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LeaderAction.class);
 
-    private static final Duration EPOCH_OFFSET_UPDATE_DURATION = Duration.ofSeconds(60);
+    private static final Duration EPOCH_OFFSET_UPDATE_DURATION = Duration.ofSeconds(300);
 
     private final TaskSyncContextHolder taskSyncContextHolder;
     private final KafkaConsumerAdminService kafkaAdminService;

--- a/src/main/java/io/debezium/connector/spanner/task/leader/LeaderAction.java
+++ b/src/main/java/io/debezium/connector/spanner/task/leader/LeaderAction.java
@@ -111,7 +111,7 @@ public class LeaderAction {
         }, "SpannerConnector-LeaderAction");
 
         thread.setUncaughtExceptionHandler((t, ex) -> {
-            LOGGER.error("Leader action execution error, task {}, ex {}", taskSyncContextHolder.get().getTaskUid(), ex.getStackTrace());
+            LOGGER.error("Leader action execution error, task {}, ex", taskSyncContextHolder.get().getTaskUid(), ex);
             errorHandler.accept(ex);
         });
 

--- a/src/main/java/io/debezium/connector/spanner/task/leader/LeaderAction.java
+++ b/src/main/java/io/debezium/connector/spanner/task/leader/LeaderAction.java
@@ -164,6 +164,8 @@ public class LeaderAction {
                 // Sleep for sleepInterval.
                 metronome.pause();
 
+                this.leaderThread.interrupt();
+
                 LOGGER.info("Task {}, still waiting for leader thread to die with rebalance generation ID {}", taskSyncContextHolder.get().getTaskUid(),
                         rebalanceGenerationId);
             }

--- a/src/main/java/io/debezium/connector/spanner/task/leader/LeaderService.java
+++ b/src/main/java/io/debezium/connector/spanner/task/leader/LeaderService.java
@@ -13,6 +13,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.slf4j.Logger;
@@ -110,10 +111,12 @@ public class LeaderService {
         while (!Thread.currentThread().isInterrupted() && consumerToTaskMap.size() < consumers.size()) {
 
             try {
+                Set<String> missingConsumers = consumers.stream().filter(c -> !consumerToTaskMap.containsKey(c)).collect(Collectors.toSet());
                 LOGGER.info("Task {} with Consumer Id {}, rebalance generation ID {}, awaitAllNewTaskStateUpdates: " +
-                        "expected: {}, actual: {}. Expected consumers: {}", taskSyncContextHolder.get().getTaskUid(), taskSyncContextHolder.get().getConsumerId(),
+                        "expected: {}, actual: {}. Expected consumers: {}, missing consumers {}", taskSyncContextHolder.get().getTaskUid(),
+                        taskSyncContextHolder.get().getConsumerId(),
                         rebalanceGenerationId,
-                        consumers.size(), consumerToTaskMap.size(), consumers);
+                        consumers.size(), consumerToTaskMap.size(), consumers, missingConsumers);
 
                 if (timeoutMeter.isExpired()) {
                     LOGGER.error("Task {} : Not received all answers from tasks", taskSyncContextHolder.get().getTaskUid());

--- a/src/main/java/io/debezium/connector/spanner/task/leader/LeaderService.java
+++ b/src/main/java/io/debezium/connector/spanner/task/leader/LeaderService.java
@@ -112,11 +112,13 @@ public class LeaderService {
 
             try {
                 Set<String> missingConsumers = consumers.stream().filter(c -> !consumerToTaskMap.containsKey(c)).collect(Collectors.toSet());
+                Set<TaskState> missingConsumerStates = taskSyncContextHolder.get().getAllTaskStates().values().stream()
+                        .filter(taskState -> missingConsumers.contains(taskState.getConsumerId())).collect(Collectors.toSet());
                 LOGGER.info("Task {} with Consumer Id {}, rebalance generation ID {}, awaitAllNewTaskStateUpdates: " +
-                        "expected: {}, actual: {}. Expected consumers: {}, missing consumers {}", taskSyncContextHolder.get().getTaskUid(),
+                        "expected: {}, actual: {}. Expected consumers: {}, missing consumers {}, consumer state {}", taskSyncContextHolder.get().getTaskUid(),
                         taskSyncContextHolder.get().getConsumerId(),
                         rebalanceGenerationId,
-                        consumers.size(), consumerToTaskMap.size(), consumers, missingConsumers);
+                        consumers.size(), consumerToTaskMap.size(), consumers, missingConsumers, missingConsumerStates);
 
                 if (timeoutMeter.isExpired()) {
                     LOGGER.error("Task {} : Not received all answers from tasks", taskSyncContextHolder.get().getTaskUid());

--- a/src/main/java/io/debezium/connector/spanner/task/leader/LowWatermarkStampPublisher.java
+++ b/src/main/java/io/debezium/connector/spanner/task/leader/LowWatermarkStampPublisher.java
@@ -86,7 +86,7 @@ public class LowWatermarkStampPublisher {
         }
 
         LOGGER.info("Task {}, Successfully destroyed LowWatermarkStampPublisher", taskSyncContextHolder.get().getTaskUid());
-        spannerEventDispatcher.publishLowWatermarkStampEvent();
+        // spannerEventDispatcher.publishLowWatermarkStampEvent();
     }
 
     private Thread createPublisherThread() {

--- a/src/main/java/io/debezium/connector/spanner/task/leader/LowWatermarkStampPublisher.java
+++ b/src/main/java/io/debezium/connector/spanner/task/leader/LowWatermarkStampPublisher.java
@@ -103,7 +103,7 @@ public class LowWatermarkStampPublisher {
                         Thread.sleep(publishInterval.toMillis());
                     }
                     catch (InterruptedException e) {
-                        LOGGER.info("Task {}, LowWatermarkStampPublisher caught exception {}", taskSyncContextHolder.get().getTaskUid(), e);
+                        LOGGER.info("Task {}, LowWatermarkStampPublisher caught exception", taskSyncContextHolder.get().getTaskUid(), e);
                         Thread.currentThread().interrupt();
                     }
                 }

--- a/src/main/java/io/debezium/connector/spanner/task/leader/LowWatermarkStampPublisher.java
+++ b/src/main/java/io/debezium/connector/spanner/task/leader/LowWatermarkStampPublisher.java
@@ -86,7 +86,6 @@ public class LowWatermarkStampPublisher {
         }
 
         LOGGER.info("Task {}, Successfully destroyed LowWatermarkStampPublisher", taskSyncContextHolder.get().getTaskUid());
-        // spannerEventDispatcher.publishLowWatermarkStampEvent();
     }
 
     private Thread createPublisherThread() {

--- a/src/main/java/io/debezium/connector/spanner/task/leader/rebalancer/TaskPartitionEqualSharingRebalancer.java
+++ b/src/main/java/io/debezium/connector/spanner/task/leader/rebalancer/TaskPartitionEqualSharingRebalancer.java
@@ -43,34 +43,34 @@ public class TaskPartitionEqualSharingRebalancer implements TaskPartitionRebalan
                                Map<String, TaskState> survivedTasks,
                                Map<String, TaskState> obsoleteTaskStates) {
 
-        LOGGER.info("Leader task state {}", leaderTaskState);
-        LOGGER.info("Survived tasks {}", survivedTasks);
-        LOGGER.info("Obsolete tasks {}", obsoleteTaskStates);
+        LOGGER.info("Leader task state {}", leaderTaskState.getTaskUid());
+        LOGGER.info("Survived tasks {}", survivedTasks.keySet().stream().collect(Collectors.toList()));
+        LOGGER.info("Obsolete tasks {}", obsoleteTaskStates.keySet().stream().collect(Collectors.toList()));
 
         TaskState newLeaderTaskState = moveFinishedPartitionsFromObsoleteTasks(leaderTaskState, obsoleteTaskStates);
-        LOGGER.info(
+        LOGGER.debug(
                 "Leader task state after moving finished partitions from obsolete tasks {}",
                 newLeaderTaskState);
 
         newLeaderTaskState = moveSharedPartitionsFromObsoleteTasks(
                 newLeaderTaskState, survivedTasks, obsoleteTaskStates);
-        LOGGER.info(
+        LOGGER.debug(
                 "Leader task state after moving finished partitions from obsolete tasks {}",
                 newLeaderTaskState);
 
         newLeaderTaskState = takeSharedPartitionsFromSurvivedTasks(newLeaderTaskState, survivedTasks);
-        LOGGER.info(
+        LOGGER.debug(
                 "Leader task state after moving shared partitions from survived tasks {}",
                 newLeaderTaskState);
 
         newLeaderTaskState = takeSharedPartitionsToObsoleteTask(newLeaderTaskState, survivedTasks);
-        LOGGER.info(
+        LOGGER.debug(
                 "Leader task state after moving shared partitions to obsolete tasks {}",
                 newLeaderTaskState);
 
         newLeaderTaskState = distributePartitionsFromObsoleteTasks(
                 newLeaderTaskState, survivedTasks, obsoleteTaskStates);
-        LOGGER.info(
+        LOGGER.debug(
                 "Leader task state after distributing partitions from obsolete tasks {}",
                 newLeaderTaskState);
 

--- a/src/main/java/io/debezium/connector/spanner/task/leader/rebalancer/TaskPartitionEqualSharingRebalancer.java
+++ b/src/main/java/io/debezium/connector/spanner/task/leader/rebalancer/TaskPartitionEqualSharingRebalancer.java
@@ -44,7 +44,6 @@ public class TaskPartitionEqualSharingRebalancer implements TaskPartitionRebalan
                                Map<String, TaskState> obsoleteTaskStates) {
 
         LOGGER.info("Leader task state {}", leaderTaskState);
-        survivedTasks = excludeLeader(leaderTaskState.getTaskUid(), survivedTasks);
         LOGGER.info("Survived tasks {}", survivedTasks);
         LOGGER.info("Obsolete tasks {}", obsoleteTaskStates);
 
@@ -76,12 +75,6 @@ public class TaskPartitionEqualSharingRebalancer implements TaskPartitionRebalan
                 newLeaderTaskState);
 
         return newLeaderTaskState;
-    }
-
-    private Map<String, TaskState> excludeLeader(String leaderTaskUid, Map<String, TaskState> tasks) {
-        tasks = new HashMap<>(tasks);
-        tasks.remove(leaderTaskUid);
-        return tasks;
     }
 
     private TaskState moveFinishedPartitionsFromObsoleteTasks(

--- a/src/main/java/io/debezium/connector/spanner/task/operation/FindPartitionForStreamingOperation.java
+++ b/src/main/java/io/debezium/connector/spanner/task/operation/FindPartitionForStreamingOperation.java
@@ -45,11 +45,6 @@ public class FindPartitionForStreamingOperation implements Operation {
                                     taskSyncContext.getTaskUid(), partitionState.getToken());
 
                         }
-                        else if (!atLeastOneParentExists(taskSyncContext, partitionState.getParents())) {
-                            LOGGER.info("Task takes partition for streaming, since parents no longer exist, taskUid: {}, partition {}, parents {}",
-                                    taskSyncContext.getTaskUid(), partitionState.getToken(), partitionState.getParents());
-                            takePartitionForStreaming = true;
-                        }
 
                         if (takePartitionForStreaming) {
                             this.isRequiredPublishSyncEvent = true;
@@ -82,24 +77,6 @@ public class FindPartitionForStreamingOperation implements Operation {
                         || PartitionStateEnum.REMOVED.equals(partitionState.getState()))
                 .map(PartitionState::getToken)
                 .collect(Collectors.toSet());
-    }
-
-    private boolean atLeastOneParentExists(TaskSyncContext taskSyncContext, Set<String> parents) {
-        List<PartitionState> partitionStateList = new ArrayList<>();
-        partitionStateList.addAll(taskSyncContext.getCurrentTaskState().getPartitions());
-        partitionStateList.addAll(taskSyncContext.getTaskStates().values().stream()
-                .flatMap(taskState -> taskState.getPartitions().stream())
-                .collect(Collectors.toList()));
-
-        Set<String> ownedPartitions = partitionStateList.stream()
-                .map(PartitionState::getToken)
-                .collect(Collectors.toSet());
-        for (String parent : parents) {
-            if (ownedPartitions.contains(parent)) {
-                return true;
-            }
-        }
-        return false;
     }
 
     @Override

--- a/src/main/java/io/debezium/connector/spanner/task/operation/RemoveFinishedPartitionOperation.java
+++ b/src/main/java/io/debezium/connector/spanner/task/operation/RemoveFinishedPartitionOperation.java
@@ -105,8 +105,7 @@ public class RemoveFinishedPartitionOperation implements Operation {
                 .build();
     }
 
-    private static boolean allChildrenFinished(
-                                               TaskSyncContext taskSyncContext, String token) {
+    private static boolean allChildrenFinished(TaskSyncContext taskSyncContext, String token) {
         List<PartitionState> allPartitionStates = Stream.concat(
                 Stream.concat(
                         taskSyncContext.getTaskStates().values().stream()

--- a/src/main/java/io/debezium/connector/spanner/task/operation/TakePartitionForStreamingOperation.java
+++ b/src/main/java/io/debezium/connector/spanner/task/operation/TakePartitionForStreamingOperation.java
@@ -58,7 +58,7 @@ public class TakePartitionForStreamingOperation implements Operation {
                 toSchedule.add(partitionState.getToken());
             }
             else {
-                LOGGER.info("Task {}, failed to submit partition {}", taskSyncContext.getTaskUid(), partitionState);
+                LOGGER.info("Task {}, failed to submit partition {} with state {}", taskSyncContext.getTaskUid(), partitionState, taskSyncContext.getRebalanceState());
             }
         });
 
@@ -75,7 +75,7 @@ public class TakePartitionForStreamingOperation implements Operation {
 
         isRequiredPublishSyncEvent = !toSchedule.isEmpty();
         if (isRequiredPublishSyncEvent) {
-            LOGGER.debug("Task scheduled {} partitions, taskUid: {}", toSchedule, taskSyncContext.getTaskUid());
+            LOGGER.info("Task scheduled {} partitions, taskUid: {}", toSchedule, taskSyncContext.getTaskUid());
         }
 
         return taskSyncContext.toBuilder()

--- a/src/main/java/io/debezium/connector/spanner/task/operation/TakePartitionForStreamingOperation.java
+++ b/src/main/java/io/debezium/connector/spanner/task/operation/TakePartitionForStreamingOperation.java
@@ -87,7 +87,7 @@ public class TakePartitionForStreamingOperation implements Operation {
                     .build();
         }
         finally {
-            LOGGER.debug("Task {}, finished trying to take partitions for streaming {}", taskSyncContext.getTaskUid(), toStreaming);
+            LOGGER.debug("Task {}, finished trying to take partitions for streaming {}", taskSyncContext.getTaskUid());
         }
     }
 

--- a/src/main/java/io/debezium/connector/spanner/task/operation/TakePartitionForStreamingOperation.java
+++ b/src/main/java/io/debezium/connector/spanner/task/operation/TakePartitionForStreamingOperation.java
@@ -5,7 +5,6 @@
  */
 package io.debezium.connector.spanner.task.operation;
 
-import java.time.Instant;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;

--- a/src/main/java/io/debezium/connector/spanner/task/operation/TakePartitionForStreamingOperation.java
+++ b/src/main/java/io/debezium/connector/spanner/task/operation/TakePartitionForStreamingOperation.java
@@ -55,6 +55,7 @@ public class TakePartitionForStreamingOperation implements Operation {
 
         toStreaming.forEach(partitionState -> {
             if (this.submitPartition(partitionState)) {
+                LOGGER.info("Task {}, submitting partition {} with state {}", taskSyncContext.getTaskUid(), partitionState, taskSyncContext.getRebalanceState());
                 toSchedule.add(partitionState.getToken());
             }
             else {

--- a/src/test/java/io/debezium/connector/spanner/db/DatabaseClientFactoryTest.java
+++ b/src/test/java/io/debezium/connector/spanner/db/DatabaseClientFactoryTest.java
@@ -32,31 +32,43 @@ class DatabaseClientFactoryTest {
         when(spannerConnectorConfig.gcpSpannerCredentialsPath()).thenReturn("Gcp Spanner Credentials Path");
         when(spannerConnectorConfig.instanceId()).thenReturn("42");
         when(spannerConnectorConfig.projectId()).thenReturn("myproject");
-        new DatabaseClientFactory(spannerConnectorConfig);
+        DatabaseClientFactory databaseClientFactory = new DatabaseClientFactory(spannerConnectorConfig);
         verify(spannerConnectorConfig).databaseId();
         verify(spannerConnectorConfig).gcpSpannerCredentialsJson();
         verify(spannerConnectorConfig).gcpSpannerCredentialsPath();
         verify(spannerConnectorConfig).instanceId();
         verify(spannerConnectorConfig).projectId();
+        databaseClientFactory.closeSpanner();
     }
 
     @Test
     void testGetGoogleCredentials() {
-        try (MockedStatic<GoogleCredentials> credentials = mockStatic(GoogleCredentials.class)) {
-            credentials.when(GoogleCredentials::getApplicationDefault).thenThrow(new IOException());
-            assertNull(new DatabaseClientFactory("myproject", "42", "42", "Credentials Json",
-                    "Credentials Path", null, "test-role")
-                    .getGoogleCredentials("Credentials Json", "Credentials Path"));
-            assertNull(new DatabaseClientFactory("myproject", "42", "42", "Credentials Json",
-                    "Credentials Path", null, "test-role")
-                    .getGoogleCredentials(null, null));
-            assertNull(new DatabaseClientFactory("myproject", "42", "42", "Credentials Json",
-                    "Credentials Path", null, "test-role")
-                    .getGoogleCredentials(null, "Credentials Path"));
-            assertNull(new DatabaseClientFactory("myproject", "42", "42", null,
-                    null, null, "test-role")
-                    .getGoogleCredentials(null, null));
-        }
+         try (MockedStatic<GoogleCredentials> credentials = mockStatic(GoogleCredentials.class)) {
+        DatabaseClientFactory databaseClientFactory1 = new DatabaseClientFactory("myproject", "42", "42", "Credentials Json",
+                "Credentials Path", null, "test-role");
+        assertNull(databaseClientFactory1
+                .getGoogleCredentials("Credentials Json", "Credentials Path"));
+        databaseClientFactory1.closeSpanner();
+
+        DatabaseClientFactory databaseClientFactory2 = new DatabaseClientFactory("myproject", "42", "42", "Credentials Json",
+                "Credentials Path", null, "test-role");
+        assertNull(databaseClientFactory2
+                .getGoogleCredentials(null, null));
+        databaseClientFactory2.closeSpanner();
+
+        DatabaseClientFactory databaseClientFactory3 = new DatabaseClientFactory("myproject", "42", "42", "Credentials Json",
+                "Credentials Path", null, "test-role");
+        assertNull(databaseClientFactory3
+                .getGoogleCredentials(null, "Credentials Path"));
+        databaseClientFactory3.closeSpanner();
+
+         DatabaseClientFactory databaseClientFactory4 = new DatabaseClientFactory("myproject", "42", "42", "Credentials Json",
+                null, null, null);
+        assertNull(databaseClientFactory4
+                .getGoogleCredentials(null, null));
+        databaseClientFactory4.closeSpanner();
+         }
+
     }
 
     @Test
@@ -66,5 +78,6 @@ class DatabaseClientFactoryTest {
 
         DatabaseClient actualDatabaseClient = databaseClientFactory.getDatabaseClient();
         assertNotNull(actualDatabaseClient);
+        databaseClientFactory.closeSpanner();
     }
 }

--- a/src/test/java/io/debezium/connector/spanner/db/DatabaseClientFactoryTest.java
+++ b/src/test/java/io/debezium/connector/spanner/db/DatabaseClientFactoryTest.java
@@ -12,8 +12,6 @@ import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.io.IOException;
-
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
@@ -43,31 +41,31 @@ class DatabaseClientFactoryTest {
 
     @Test
     void testGetGoogleCredentials() {
-         try (MockedStatic<GoogleCredentials> credentials = mockStatic(GoogleCredentials.class)) {
-        DatabaseClientFactory databaseClientFactory1 = new DatabaseClientFactory("myproject", "42", "42", "Credentials Json",
-                "Credentials Path", null, "test-role");
-        assertNull(databaseClientFactory1
-                .getGoogleCredentials("Credentials Json", "Credentials Path"));
-        databaseClientFactory1.closeSpanner();
+        try (MockedStatic<GoogleCredentials> credentials = mockStatic(GoogleCredentials.class)) {
+            DatabaseClientFactory databaseClientFactory1 = new DatabaseClientFactory("myproject", "42", "42", "Credentials Json",
+                    "Credentials Path", null, "test-role");
+            assertNull(databaseClientFactory1
+                    .getGoogleCredentials("Credentials Json", "Credentials Path"));
+            databaseClientFactory1.closeSpanner();
 
-        DatabaseClientFactory databaseClientFactory2 = new DatabaseClientFactory("myproject", "42", "42", "Credentials Json",
-                "Credentials Path", null, "test-role");
-        assertNull(databaseClientFactory2
-                .getGoogleCredentials(null, null));
-        databaseClientFactory2.closeSpanner();
+            DatabaseClientFactory databaseClientFactory2 = new DatabaseClientFactory("myproject", "42", "42", "Credentials Json",
+                    "Credentials Path", null, "test-role");
+            assertNull(databaseClientFactory2
+                    .getGoogleCredentials(null, null));
+            databaseClientFactory2.closeSpanner();
 
-        DatabaseClientFactory databaseClientFactory3 = new DatabaseClientFactory("myproject", "42", "42", "Credentials Json",
-                "Credentials Path", null, "test-role");
-        assertNull(databaseClientFactory3
-                .getGoogleCredentials(null, "Credentials Path"));
-        databaseClientFactory3.closeSpanner();
+            DatabaseClientFactory databaseClientFactory3 = new DatabaseClientFactory("myproject", "42", "42", "Credentials Json",
+                    "Credentials Path", null, "test-role");
+            assertNull(databaseClientFactory3
+                    .getGoogleCredentials(null, "Credentials Path"));
+            databaseClientFactory3.closeSpanner();
 
-         DatabaseClientFactory databaseClientFactory4 = new DatabaseClientFactory("myproject", "42", "42", "Credentials Json",
-                null, null, null);
-        assertNull(databaseClientFactory4
-                .getGoogleCredentials(null, null));
-        databaseClientFactory4.closeSpanner();
-         }
+            DatabaseClientFactory databaseClientFactory4 = new DatabaseClientFactory("myproject", "42", "42", "Credentials Json",
+                    null, null, null);
+            assertNull(databaseClientFactory4
+                    .getGoogleCredentials(null, null));
+            databaseClientFactory4.closeSpanner();
+        }
 
     }
 

--- a/src/test/java/io/debezium/connector/spanner/db/SpannerChangeStreamFactoryTest.java
+++ b/src/test/java/io/debezium/connector/spanner/db/SpannerChangeStreamFactoryTest.java
@@ -12,8 +12,6 @@ import java.time.Duration;
 
 import org.junit.jupiter.api.Test;
 
-import com.google.cloud.spanner.Dialect;
-
 import io.debezium.connector.spanner.db.stream.SpannerChangeStream;
 import io.debezium.connector.spanner.metrics.MetricsEventPublisher;
 
@@ -25,7 +23,7 @@ class SpannerChangeStreamFactoryTest {
         DaoFactory daoFactory = new DaoFactory(databaseClientFactory);
         SpannerChangeStreamFactory spannerChangeStreamFactory = new SpannerChangeStreamFactory(
                 "taskUid", daoFactory, new MetricsEventPublisher(), "test-connector",
-                Dialect.GOOGLE_STANDARD_SQL, databaseClientFactory);
+                databaseClientFactory);
         SpannerChangeStream stream = spannerChangeStreamFactory.getStream("stream1",
                 Duration.ofMillis(100), 1);
         assertNotNull(stream);

--- a/src/test/java/io/debezium/connector/spanner/db/mapper/ChangeStreamRecordMapperTest.java
+++ b/src/test/java/io/debezium/connector/spanner/db/mapper/ChangeStreamRecordMapperTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.cloud.Timestamp;
+import com.google.cloud.spanner.DatabaseClient;
 import com.google.cloud.spanner.Dialect;
 import com.google.cloud.spanner.Struct;
 import com.google.cloud.spanner.Type;
@@ -54,9 +55,12 @@ class ChangeStreamRecordMapperTest {
     ChangeStreamResultSetMetadata resultSetMetadata;
     Partition partition;
     ChangeStreamRecordMapper changeStreamRecordMapper;
+    DatabaseClient psqlDatabaseClient = mock(DatabaseClient.class);
+    DatabaseClient gsqlDatabaseClient = mock(DatabaseClient.class);
 
     @BeforeEach
     public void setUp() {
+        when(psqlDatabaseClient.getDialect()).thenReturn(Dialect.POSTGRESQL);
         resultSetMetadata = mock(ChangeStreamResultSetMetadata.class);
         when(resultSetMetadata.getQueryStartedAt()).thenReturn(Timestamp.ofTimeMicroseconds(1L));
         when(resultSetMetadata.getRecordStreamStartedAt()).thenReturn(Timestamp.ofTimeMicroseconds(2L));
@@ -67,7 +71,7 @@ class ChangeStreamRecordMapperTest {
         partition = new Partition("partitionToken", Sets.newHashSet("parentToken"), Timestamp.ofTimeMicroseconds(11L),
                 Timestamp.ofTimeMicroseconds(12L), "parentToken");
         changeStreamRecordMapper = new ChangeStreamRecordMapper(
-                Dialect.POSTGRESQL);
+                psqlDatabaseClient);
     }
 
     @Test
@@ -333,8 +337,9 @@ class ChangeStreamRecordMapperTest {
 
     @Test
     void testToChangeStreamEvents() {
+        when(gsqlDatabaseClient.getDialect()).thenReturn(Dialect.GOOGLE_STANDARD_SQL);
         ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(
-                Dialect.GOOGLE_STANDARD_SQL);
+                gsqlDatabaseClient);
         HashSet<String> parentTokens = new HashSet<>();
         Timestamp startTimestamp = Timestamp.ofTimeMicroseconds(1L);
         Partition partition = new Partition("token", parentTokens, startTimestamp, Timestamp.ofTimeMicroseconds(1L), "originPartition");
@@ -352,7 +357,8 @@ class ChangeStreamRecordMapperTest {
 
     @Test
     void testToChangeStreamEvents2() {
-        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(Dialect.GOOGLE_STANDARD_SQL);
+        when(gsqlDatabaseClient.getDialect()).thenReturn(Dialect.GOOGLE_STANDARD_SQL);
+        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(gsqlDatabaseClient);
         HashSet<String> parentTokens = new HashSet<>();
         Timestamp startTimestamp = Timestamp.ofTimeMicroseconds(1L);
         Partition partition = new Partition("token", parentTokens, startTimestamp, Timestamp.ofTimeMicroseconds(1L), "originPartition");
@@ -377,7 +383,8 @@ class ChangeStreamRecordMapperTest {
 
     @Test
     void testToChangeStreamEvents3() {
-        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(Dialect.GOOGLE_STANDARD_SQL);
+        when(gsqlDatabaseClient.getDialect()).thenReturn(Dialect.GOOGLE_STANDARD_SQL);
+        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(gsqlDatabaseClient);
         HashSet<String> parentTokens = new HashSet<>();
         Timestamp startTimestamp = Timestamp.ofTimeMicroseconds(1L);
         Partition partition = new Partition("token", parentTokens, startTimestamp, Timestamp.ofTimeMicroseconds(1L), "originPartition");
@@ -407,7 +414,8 @@ class ChangeStreamRecordMapperTest {
 
     @Test
     void testToChangeStreamEvents4() {
-        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(Dialect.GOOGLE_STANDARD_SQL);
+        when(gsqlDatabaseClient.getDialect()).thenReturn(Dialect.GOOGLE_STANDARD_SQL);
+        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(gsqlDatabaseClient);
         HashSet<String> parentTokens = new HashSet<>();
         Timestamp startTimestamp = Timestamp.ofTimeMicroseconds(1L);
         Partition partition = new Partition("token", parentTokens, startTimestamp, Timestamp.ofTimeMicroseconds(1L), "originPartition");
@@ -439,7 +447,8 @@ class ChangeStreamRecordMapperTest {
 
     @Test
     void testToChangeStreamEvents5() {
-        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(Dialect.GOOGLE_STANDARD_SQL);
+        when(gsqlDatabaseClient.getDialect()).thenReturn(Dialect.GOOGLE_STANDARD_SQL);
+        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(gsqlDatabaseClient);
         HashSet<String> parentTokens = new HashSet<>();
         Timestamp startTimestamp = Timestamp.ofTimeMicroseconds(1L);
         Partition partition = new Partition("String", parentTokens, startTimestamp, Timestamp.ofTimeMicroseconds(1L), "originPartition");
@@ -456,7 +465,8 @@ class ChangeStreamRecordMapperTest {
 
     @Test
     void testToChangeStreamEvents6() {
-        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(Dialect.GOOGLE_STANDARD_SQL);
+        when(gsqlDatabaseClient.getDialect()).thenReturn(Dialect.GOOGLE_STANDARD_SQL);
+        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(gsqlDatabaseClient);
         HashSet<String> parentTokens = new HashSet<>();
         Timestamp startTimestamp = Timestamp.ofTimeMicroseconds(1L);
         Partition partition = new Partition("String", parentTokens, startTimestamp, Timestamp.ofTimeMicroseconds(1L), "originPartition");
@@ -478,7 +488,8 @@ class ChangeStreamRecordMapperTest {
 
     @Test
     void testToChangeStreamEvents7() {
-        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(Dialect.GOOGLE_STANDARD_SQL);
+        when(gsqlDatabaseClient.getDialect()).thenReturn(Dialect.GOOGLE_STANDARD_SQL);
+        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(gsqlDatabaseClient);
         HashSet<String> parentTokens = new HashSet<>();
         Timestamp startTimestamp = Timestamp.ofTimeMicroseconds(1L);
         Partition partition = new Partition("String", parentTokens, startTimestamp, Timestamp.ofTimeMicroseconds(1L), "originPartition");
@@ -504,7 +515,8 @@ class ChangeStreamRecordMapperTest {
 
     @Test
     void testToChangeStreamEvents8() {
-        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(Dialect.GOOGLE_STANDARD_SQL);
+        when(gsqlDatabaseClient.getDialect()).thenReturn(Dialect.GOOGLE_STANDARD_SQL);
+        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(gsqlDatabaseClient);
         HashSet<String> parentTokens = new HashSet<>();
         Timestamp startTimestamp = Timestamp.ofTimeMicroseconds(1L);
         Partition partition = new Partition("String", parentTokens, startTimestamp, Timestamp.ofTimeMicroseconds(1L), "originPartition");
@@ -532,7 +544,8 @@ class ChangeStreamRecordMapperTest {
 
     @Test
     void testToStreamEvent() {
-        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(Dialect.GOOGLE_STANDARD_SQL);
+        when(gsqlDatabaseClient.getDialect()).thenReturn(Dialect.GOOGLE_STANDARD_SQL);
+        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(gsqlDatabaseClient);
         HashSet<String> parentTokens = new HashSet<>();
         Timestamp startTimestamp = Timestamp.ofTimeMicroseconds(1L);
         Partition partition = new Partition("String", parentTokens, startTimestamp, Timestamp.ofTimeMicroseconds(1L), "originPartition");
@@ -549,7 +562,8 @@ class ChangeStreamRecordMapperTest {
 
     @Test
     void testToStreamEventThrows() {
-        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(Dialect.GOOGLE_STANDARD_SQL);
+        when(gsqlDatabaseClient.getDialect()).thenReturn(Dialect.GOOGLE_STANDARD_SQL);
+        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(gsqlDatabaseClient);
         HashSet<String> parentTokens = new HashSet<>();
         Timestamp startTimestamp = Timestamp.ofTimeMicroseconds(1L);
         Partition partition = new Partition("String", parentTokens, startTimestamp, Timestamp.ofTimeMicroseconds(1L), "originPartition");
@@ -567,7 +581,8 @@ class ChangeStreamRecordMapperTest {
 
     @Test
     void testIsNonNullDataChangeRecordNullDataChangeRecord() {
-        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(Dialect.GOOGLE_STANDARD_SQL);
+        when(gsqlDatabaseClient.getDialect()).thenReturn(Dialect.GOOGLE_STANDARD_SQL);
+        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(gsqlDatabaseClient);
         Struct struct = mock(Struct.class);
         when(struct.isNull(any())).thenReturn(true);
         assertFalse(changeStreamRecordMapper.isNonNullDataChangeRecord(struct));
@@ -576,7 +591,8 @@ class ChangeStreamRecordMapperTest {
 
     @Test
     void testIsNonNullDataChangeRecordNonNullDataChangeRecord() {
-        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(Dialect.GOOGLE_STANDARD_SQL);
+        when(gsqlDatabaseClient.getDialect()).thenReturn(Dialect.GOOGLE_STANDARD_SQL);
+        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(gsqlDatabaseClient);
         Struct struct = mock(Struct.class);
         when(struct.isNull(any())).thenReturn(false);
         assertTrue(changeStreamRecordMapper.isNonNullDataChangeRecord(struct));
@@ -585,7 +601,8 @@ class ChangeStreamRecordMapperTest {
 
     @Test
     void testIsNonNullDataChangeRecordThrows() {
-        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(Dialect.GOOGLE_STANDARD_SQL);
+        when(gsqlDatabaseClient.getDialect()).thenReturn(Dialect.GOOGLE_STANDARD_SQL);
+        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(gsqlDatabaseClient);
         Struct struct = mock(Struct.class);
         when(struct.isNull(any())).thenThrow(new IllegalArgumentException());
         assertThrows(IllegalArgumentException.class, () -> changeStreamRecordMapper.isNonNullDataChangeRecord(struct));
@@ -594,7 +611,8 @@ class ChangeStreamRecordMapperTest {
 
     @Test
     void testIsNonNullHeartbeatRecordNullHeartbeatRecord() {
-        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(Dialect.GOOGLE_STANDARD_SQL);
+        when(gsqlDatabaseClient.getDialect()).thenReturn(Dialect.GOOGLE_STANDARD_SQL);
+        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(gsqlDatabaseClient);
         Struct struct = mock(Struct.class);
         when(struct.isNull(any())).thenReturn(true);
         assertFalse(changeStreamRecordMapper.isNonNullHeartbeatRecord(struct));
@@ -603,7 +621,8 @@ class ChangeStreamRecordMapperTest {
 
     @Test
     void testIsNonNullHeartbeatRecordNonNullHeartbeatRecord() {
-        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(Dialect.GOOGLE_STANDARD_SQL);
+        when(gsqlDatabaseClient.getDialect()).thenReturn(Dialect.GOOGLE_STANDARD_SQL);
+        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(gsqlDatabaseClient);
         Struct struct = mock(Struct.class);
         when(struct.isNull(any())).thenReturn(false);
         assertTrue(changeStreamRecordMapper.isNonNullHeartbeatRecord(struct));
@@ -612,7 +631,8 @@ class ChangeStreamRecordMapperTest {
 
     @Test
     void testIsNonNullHeartbeatRecordThrows() {
-        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(Dialect.GOOGLE_STANDARD_SQL);
+        when(gsqlDatabaseClient.getDialect()).thenReturn(Dialect.GOOGLE_STANDARD_SQL);
+        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(gsqlDatabaseClient);
         Struct struct = mock(Struct.class);
         when(struct.isNull(any())).thenThrow(new IllegalArgumentException());
         assertThrows(IllegalArgumentException.class, () -> changeStreamRecordMapper.isNonNullHeartbeatRecord(struct));
@@ -621,7 +641,8 @@ class ChangeStreamRecordMapperTest {
 
     @Test
     void testIsNonNullChildPartitionsRecordNullChildPartitionsRecord() {
-        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(Dialect.GOOGLE_STANDARD_SQL);
+        when(gsqlDatabaseClient.getDialect()).thenReturn(Dialect.GOOGLE_STANDARD_SQL);
+        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(gsqlDatabaseClient);
         Struct struct = mock(Struct.class);
         when(struct.isNull(any())).thenReturn(true);
         assertFalse(changeStreamRecordMapper.isNonNullChildPartitionsRecord(struct));
@@ -630,7 +651,8 @@ class ChangeStreamRecordMapperTest {
 
     @Test
     void testIsNonNullChildPartitionsRecordNonNullChildPartitionsRecord() {
-        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(Dialect.GOOGLE_STANDARD_SQL);
+        when(gsqlDatabaseClient.getDialect()).thenReturn(Dialect.GOOGLE_STANDARD_SQL);
+        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(gsqlDatabaseClient);
         Struct struct = mock(Struct.class);
         when(struct.isNull(any())).thenReturn(false);
         assertTrue(changeStreamRecordMapper.isNonNullChildPartitionsRecord(struct));
@@ -639,7 +661,8 @@ class ChangeStreamRecordMapperTest {
 
     @Test
     void testIsNonNullChildPartitionsRecordThrows() {
-        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(Dialect.GOOGLE_STANDARD_SQL);
+        when(gsqlDatabaseClient.getDialect()).thenReturn(Dialect.GOOGLE_STANDARD_SQL);
+        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(gsqlDatabaseClient);
         Struct struct = mock(Struct.class);
         when(struct.isNull(any())).thenThrow(new IllegalArgumentException());
         assertThrows(IllegalArgumentException.class,
@@ -649,7 +672,8 @@ class ChangeStreamRecordMapperTest {
 
     @Test
     void testToDataChangeEvent() {
-        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(Dialect.GOOGLE_STANDARD_SQL);
+        when(gsqlDatabaseClient.getDialect()).thenReturn(Dialect.GOOGLE_STANDARD_SQL);
+        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(gsqlDatabaseClient);
         HashSet<String> parentTokens = new HashSet<>();
         Timestamp startTimestamp = Timestamp.ofTimeMicroseconds(1L);
         Partition partition = new Partition("String", parentTokens, startTimestamp, Timestamp.ofTimeMicroseconds(1L), "originPartition");
@@ -673,7 +697,8 @@ class ChangeStreamRecordMapperTest {
 
     @Test
     void testToDataChangeEventThrows() {
-        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(Dialect.GOOGLE_STANDARD_SQL);
+        when(gsqlDatabaseClient.getDialect()).thenReturn(Dialect.GOOGLE_STANDARD_SQL);
+        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(gsqlDatabaseClient);
         HashSet<String> parentTokens = new HashSet<>();
         Timestamp startTimestamp = Timestamp.ofTimeMicroseconds(1L);
         Partition partition = new Partition("String", parentTokens, startTimestamp, Timestamp.ofTimeMicroseconds(1L), "originPartition");
@@ -699,7 +724,8 @@ class ChangeStreamRecordMapperTest {
 
     @Test
     void testToHeartbeatEvent() {
-        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(Dialect.GOOGLE_STANDARD_SQL);
+        when(gsqlDatabaseClient.getDialect()).thenReturn(Dialect.GOOGLE_STANDARD_SQL);
+        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(gsqlDatabaseClient);
         HashSet<String> parentTokens = new HashSet<>();
         Timestamp ofTimeMicrosecondsResult = Timestamp.ofTimeMicroseconds(1L);
         Partition partition = new Partition("String", parentTokens, ofTimeMicrosecondsResult,
@@ -741,7 +767,8 @@ class ChangeStreamRecordMapperTest {
 
     @Test
     void testToHeartbeatEvent2() {
-        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(Dialect.GOOGLE_STANDARD_SQL);
+        when(gsqlDatabaseClient.getDialect()).thenReturn(Dialect.GOOGLE_STANDARD_SQL);
+        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(gsqlDatabaseClient);
         HashSet<String> parentTokens = new HashSet<>();
         Timestamp startTimestamp = Timestamp.ofTimeMicroseconds(1L);
         Partition partition = new Partition("String", parentTokens, startTimestamp, Timestamp.ofTimeMicroseconds(1L), "originPartition");
@@ -768,7 +795,8 @@ class ChangeStreamRecordMapperTest {
 
     @Test
     void testToChildPartitionsEvent() {
-        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(Dialect.GOOGLE_STANDARD_SQL);
+        when(gsqlDatabaseClient.getDialect()).thenReturn(Dialect.GOOGLE_STANDARD_SQL);
+        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(gsqlDatabaseClient);
         HashSet<String> parentTokens = new HashSet<>();
         Timestamp ofTimeMicrosecondsResult = Timestamp.ofTimeMicroseconds(1L);
         Partition partition = new Partition("String", parentTokens, ofTimeMicrosecondsResult,
@@ -816,7 +844,8 @@ class ChangeStreamRecordMapperTest {
 
     @Test
     void testToChildPartitionsEventThrows() {
-        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(Dialect.GOOGLE_STANDARD_SQL);
+        when(gsqlDatabaseClient.getDialect()).thenReturn(Dialect.GOOGLE_STANDARD_SQL);
+        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(gsqlDatabaseClient);
         HashSet<String> parentTokens = new HashSet<>();
         Timestamp startTimestamp = Timestamp.ofTimeMicroseconds(1L);
         Partition partition = new Partition("String", parentTokens, startTimestamp, Timestamp.ofTimeMicroseconds(1L), "originPartition");
@@ -847,7 +876,8 @@ class ChangeStreamRecordMapperTest {
 
     @Test
     void testToChildPartitionsEvent4() {
-        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(Dialect.GOOGLE_STANDARD_SQL);
+        when(gsqlDatabaseClient.getDialect()).thenReturn(Dialect.GOOGLE_STANDARD_SQL);
+        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(gsqlDatabaseClient);
         HashSet<String> parentTokens = new HashSet<>();
         Timestamp ofTimeMicrosecondsResult = Timestamp.ofTimeMicroseconds(1L);
         Partition partition = new Partition("String", parentTokens, ofTimeMicrosecondsResult,
@@ -911,7 +941,8 @@ class ChangeStreamRecordMapperTest {
      */
     @Test
     void testToChildPartitionsEvent5() {
-        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(Dialect.GOOGLE_STANDARD_SQL);
+        when(gsqlDatabaseClient.getDialect()).thenReturn(Dialect.GOOGLE_STANDARD_SQL);
+        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(gsqlDatabaseClient);
         HashSet<String> parentTokens = new HashSet<>();
         Timestamp ofTimeMicrosecondsResult = Timestamp.ofTimeMicroseconds(1L);
         Partition partition = new Partition("Parent0", parentTokens, ofTimeMicrosecondsResult,
@@ -972,7 +1003,8 @@ class ChangeStreamRecordMapperTest {
 
     @Test
     void testToChildPartitionsEvent7() {
-        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(Dialect.GOOGLE_STANDARD_SQL);
+        when(gsqlDatabaseClient.getDialect()).thenReturn(Dialect.GOOGLE_STANDARD_SQL);
+        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(gsqlDatabaseClient);
         HashSet<String> parentTokens = new HashSet<>();
         Timestamp ofTimeMicrosecondsResult = Timestamp.ofTimeMicroseconds(1L);
         Partition partition = new Partition("String", parentTokens, ofTimeMicrosecondsResult,
@@ -1043,7 +1075,8 @@ class ChangeStreamRecordMapperTest {
 
     @Test
     void testColumnTypeFrom() {
-        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(Dialect.GOOGLE_STANDARD_SQL);
+        when(gsqlDatabaseClient.getDialect()).thenReturn(Dialect.GOOGLE_STANDARD_SQL);
+        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(gsqlDatabaseClient);
         Struct struct = mock(Struct.class);
         when(struct.getColumnType(any())).thenReturn(Type.string());
         when(struct.getString(any())).thenReturn("{\"code\":\"STRING\"}");
@@ -1054,7 +1087,8 @@ class ChangeStreamRecordMapperTest {
 
     @Test
     void testColumnTypeFromThrowsBool() {
-        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(Dialect.GOOGLE_STANDARD_SQL);
+        when(gsqlDatabaseClient.getDialect()).thenReturn(Dialect.GOOGLE_STANDARD_SQL);
+        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(gsqlDatabaseClient);
         Struct struct = mock(Struct.class);
         when(struct.getColumnType(any())).thenReturn(Type.bool());
         assertThrows(IllegalArgumentException.class, () -> changeStreamRecordMapper.columnTypeFrom(struct));
@@ -1063,7 +1097,8 @@ class ChangeStreamRecordMapperTest {
 
     @Test
     void testColumnTypeFromThrows() {
-        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(Dialect.GOOGLE_STANDARD_SQL);
+        when(gsqlDatabaseClient.getDialect()).thenReturn(Dialect.GOOGLE_STANDARD_SQL);
+        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(gsqlDatabaseClient);
         Struct struct = mock(Struct.class);
         when(struct.getColumnType(any())).thenThrow(new IllegalArgumentException());
         assertThrows(IllegalArgumentException.class, () -> changeStreamRecordMapper.columnTypeFrom(struct));
@@ -1072,7 +1107,8 @@ class ChangeStreamRecordMapperTest {
 
     @Test
     void testModFrom() {
-        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(Dialect.GOOGLE_STANDARD_SQL);
+        when(gsqlDatabaseClient.getDialect()).thenReturn(Dialect.GOOGLE_STANDARD_SQL);
+        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(gsqlDatabaseClient);
         Struct struct = mock(Struct.class);
         when(struct.getColumnType(any())).thenReturn(Type.bool());
         assertThrows(IllegalArgumentException.class, () -> changeStreamRecordMapper.modFrom(0, struct));
@@ -1081,7 +1117,8 @@ class ChangeStreamRecordMapperTest {
 
     @Test
     void testModFromString() {
-        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(Dialect.GOOGLE_STANDARD_SQL);
+        when(gsqlDatabaseClient.getDialect()).thenReturn(Dialect.GOOGLE_STANDARD_SQL);
+        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(gsqlDatabaseClient);
         Struct struct = mock(Struct.class);
         when(struct.getColumnType(any())).thenReturn(Type.string());
         String jsonString = "{\"code\":\"STRING\"}";
@@ -1097,7 +1134,8 @@ class ChangeStreamRecordMapperTest {
 
     @Test
     void testEmptyChildPartitionFrom() {
-        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(Dialect.GOOGLE_STANDARD_SQL);
+        when(gsqlDatabaseClient.getDialect()).thenReturn(Dialect.GOOGLE_STANDARD_SQL);
+        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(gsqlDatabaseClient);
         Struct struct = mock(Struct.class);
         when(struct.getString(any())).thenReturn("String");
         when(struct.getStringList(any())).thenReturn(new ArrayList<>());
@@ -1110,7 +1148,8 @@ class ChangeStreamRecordMapperTest {
 
     @Test
     void testChildPartitionFrom() {
-        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(Dialect.GOOGLE_STANDARD_SQL);
+        when(gsqlDatabaseClient.getDialect()).thenReturn(Dialect.GOOGLE_STANDARD_SQL);
+        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(gsqlDatabaseClient);
         Struct struct = mock(Struct.class);
         when(struct.getString(any())).thenReturn("String");
         when(struct.getStringList(any())).thenReturn(new ArrayList<>());
@@ -1123,7 +1162,8 @@ class ChangeStreamRecordMapperTest {
 
     @Test
     void testChildPartitionFromThrows() {
-        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(Dialect.GOOGLE_STANDARD_SQL);
+        when(gsqlDatabaseClient.getDialect()).thenReturn(Dialect.GOOGLE_STANDARD_SQL);
+        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(gsqlDatabaseClient);
         Struct struct = mock(Struct.class);
         when(struct.getString(any())).thenThrow(new IllegalArgumentException());
         when(struct.getStringList(any())).thenThrow(new IllegalArgumentException());
@@ -1133,7 +1173,8 @@ class ChangeStreamRecordMapperTest {
 
     @Test
     void testStreamEventMetadataFrom() {
-        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(Dialect.GOOGLE_STANDARD_SQL);
+        when(gsqlDatabaseClient.getDialect()).thenReturn(Dialect.GOOGLE_STANDARD_SQL);
+        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(gsqlDatabaseClient);
         HashSet<String> parentTokens = new HashSet<>();
         Timestamp ofTimeMicrosecondsResult = Timestamp.ofTimeMicroseconds(1L);
         Partition partition = new Partition("String", parentTokens, ofTimeMicrosecondsResult,
@@ -1172,7 +1213,8 @@ class ChangeStreamRecordMapperTest {
 
     @Test
     void testGetJsonStringThrows() {
-        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(Dialect.GOOGLE_STANDARD_SQL);
+        when(gsqlDatabaseClient.getDialect()).thenReturn(Dialect.GOOGLE_STANDARD_SQL);
+        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(gsqlDatabaseClient);
         Struct struct = mock(Struct.class);
         when(struct.getColumnType(any())).thenReturn(Type.bool());
         assertThrows(IllegalArgumentException.class, () -> changeStreamRecordMapper.getJsonString(struct, "Column Name"));
@@ -1181,7 +1223,8 @@ class ChangeStreamRecordMapperTest {
 
     @Test
     void testGetJsonString() {
-        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(Dialect.GOOGLE_STANDARD_SQL);
+        when(gsqlDatabaseClient.getDialect()).thenReturn(Dialect.GOOGLE_STANDARD_SQL);
+        ChangeStreamRecordMapper changeStreamRecordMapper = new ChangeStreamRecordMapper(gsqlDatabaseClient);
         Struct struct = mock(Struct.class);
         when(struct.getJson(any())).thenReturn("Json");
         when(struct.getColumnType(any())).thenReturn(Type.json());

--- a/src/test/java/io/debezium/connector/spanner/db/stream/SpannerChangeStreamServiceTest.java
+++ b/src/test/java/io/debezium/connector/spanner/db/stream/SpannerChangeStreamServiceTest.java
@@ -18,6 +18,7 @@ import java.util.HashSet;
 import org.junit.jupiter.api.Test;
 
 import com.google.cloud.Timestamp;
+import com.google.cloud.spanner.DatabaseClient;
 import com.google.cloud.spanner.Dialect;
 
 import io.debezium.connector.spanner.db.dao.ChangeStreamDao;
@@ -36,8 +37,10 @@ class SpannerChangeStreamServiceTest {
         when(changeStreamResultSet.next()).thenReturn(false);
         when(changeStreamDao.streamQuery(any(), any(), any(), anyLong())).thenReturn(changeStreamResultSet);
 
+        DatabaseClient gsqlDatabaseClient = mock(DatabaseClient.class);
+        when(gsqlDatabaseClient.getDialect()).thenReturn(Dialect.GOOGLE_STANDARD_SQL);
         SpannerChangeStreamService spannerChangeStreamService = new SpannerChangeStreamService("TaskUid", changeStreamDao,
-                new ChangeStreamRecordMapper(Dialect.GOOGLE_STANDARD_SQL), Duration.ofMillis(1000), metricsEventPublisher);
+                new ChangeStreamRecordMapper(gsqlDatabaseClient), Duration.ofMillis(1000), metricsEventPublisher);
 
         HashSet<String> parentTokens = new HashSet<>();
         Timestamp startTimestamp = Timestamp.ofTimeMicroseconds(1L);

--- a/src/test/java/io/debezium/connector/spanner/db/stream/SpannerChangeStreamTest.java
+++ b/src/test/java/io/debezium/connector/spanner/db/stream/SpannerChangeStreamTest.java
@@ -194,6 +194,6 @@ class SpannerChangeStreamTest {
         Awaitility.await().atMost(10, TimeUnit.SECONDS)
                 .until(() -> spannerChangeStream.submitPartition(partition));
 
-        verify(metricsEventPublisher, times(2)).publishMetricEvent(any());
+        // verify(metricsEventPublisher, times(2)).publishMetricEvent(any());
     }
 }

--- a/src/test/java/io/debezium/connector/spanner/db/stream/SpannerChangeStreamTest.java
+++ b/src/test/java/io/debezium/connector/spanner/db/stream/SpannerChangeStreamTest.java
@@ -107,8 +107,6 @@ class SpannerChangeStreamTest {
         SpannerChangeStream spannerChangeStream = new SpannerChangeStream(streamService, metricsEventPublisher, Duration.ofSeconds(60), 3, "taskUid",
                 databaseClientFactory);
         spannerChangeStream.stop();
-        spannerChangeStream.stop("test");
-        verify(metricsEventPublisher).publishMetricEvent(any());
     }
 
     @Test

--- a/src/test/java/io/debezium/connector/spanner/db/stream/SpannerChangeStreamTest.java
+++ b/src/test/java/io/debezium/connector/spanner/db/stream/SpannerChangeStreamTest.java
@@ -194,6 +194,6 @@ class SpannerChangeStreamTest {
         Awaitility.await().atMost(10, TimeUnit.SECONDS)
                 .until(() -> spannerChangeStream.submitPartition(partition));
 
-        // verify(metricsEventPublisher, times(2)).publishMetricEvent(any());
+        verify(metricsEventPublisher, times(2)).publishMetricEvent(any());
     }
 }

--- a/src/test/java/io/debezium/connector/spanner/task/SyncEventMergerTest.java
+++ b/src/test/java/io/debezium/connector/spanner/task/SyncEventMergerTest.java
@@ -5,10 +5,8 @@
  */
 package io.debezium.connector.spanner.task;
 
-import static io.debezium.connector.spanner.task.SyncEventMerger.mergeEpochUpdate;
 import static io.debezium.connector.spanner.task.SyncEventMerger.mergeIncrementalTaskSyncEvent;
 import static io.debezium.connector.spanner.task.SyncEventMerger.mergeNewEpoch;
-import static io.debezium.connector.spanner.task.SyncEventMerger.mergeRebalanceAnswer;
 import static io.debezium.connector.spanner.task.TaskTestHelper.generateTaskStateWithPartitions;
 
 import java.util.List;
@@ -23,47 +21,47 @@ import io.debezium.connector.spanner.kafka.internal.model.TaskState;
 import io.debezium.connector.spanner.kafka.internal.model.TaskSyncEvent;
 
 class SyncEventMergerTest {
-    @Test
-    void testMergeRebalanceAnswer() {
-        TaskSyncContext taskSyncContext1 = buildTaskSyncContext1();
-        TaskSyncContext taskSyncContext2 = buildTaskSyncContext2();
+    // @Test
+    // void testMergeRebalanceAnswer() {
+    // TaskSyncContext taskSyncContext1 = buildTaskSyncContext1();
+    // TaskSyncContext taskSyncContext2 = buildTaskSyncContext2();
 
-        TaskSyncEvent rebalanceAnswer1 = taskSyncContext1.buildRebalanceAnswerTaskSyncEvent();
-        TaskSyncContext mergedRebalanceAnswer = mergeRebalanceAnswer(
-                taskSyncContext2, rebalanceAnswer1);
+    // TaskSyncEvent rebalanceAnswer1 = taskSyncContext1.buildRebalanceAnswerTaskSyncEvent();
+    // TaskSyncContext mergedRebalanceAnswer = mergeRebalanceAnswer(
+    // taskSyncContext2, rebalanceAnswer1);
 
-        Assertions.assertEquals("task2", mergedRebalanceAnswer.getTaskUid());
-        Assertions.assertEquals(2, mergedRebalanceAnswer.getTaskStates().size());
+    // Assertions.assertEquals("task2", mergedRebalanceAnswer.getTaskUid());
+    // Assertions.assertEquals(2, mergedRebalanceAnswer.getTaskStates().size());
 
-        TaskState taskState1 = mergedRebalanceAnswer.getTaskStates().get("task0");
-        Assertions.assertEquals(taskState1.getTaskUid(), "task0");
+    // TaskState taskState1 = mergedRebalanceAnswer.getTaskStates().get("task0");
+    // Assertions.assertEquals(taskState1.getTaskUid(), "task0");
 
-        Assertions.assertEquals(taskState1.getPartitionsMap().size(), 4);
-        PartitionState partition1 = taskState1.getPartitionsMap().get("token0");
-        Assertions.assertEquals(partition1.getState(), PartitionStateEnum.CREATED);
-        PartitionState partition2 = taskState1.getPartitionsMap().get("token1");
-        Assertions.assertEquals(partition2.getState(), PartitionStateEnum.REMOVED);
-        PartitionState partition3 = taskState1.getPartitionsMap().get("token2");
-        Assertions.assertEquals(partition3.getState(), PartitionStateEnum.RUNNING);
-        PartitionState partition4 = taskState1.getPartitionsMap().get("token3");
-        Assertions.assertEquals(partition4.getState(), PartitionStateEnum.FINISHED);
+    // Assertions.assertEquals(taskState1.getPartitionsMap().size(), 4);
+    // PartitionState partition1 = taskState1.getPartitionsMap().get("token0");
+    // Assertions.assertEquals(partition1.getState(), PartitionStateEnum.CREATED);
+    // PartitionState partition2 = taskState1.getPartitionsMap().get("token1");
+    // Assertions.assertEquals(partition2.getState(), PartitionStateEnum.REMOVED);
+    // PartitionState partition3 = taskState1.getPartitionsMap().get("token2");
+    // Assertions.assertEquals(partition3.getState(), PartitionStateEnum.RUNNING);
+    // PartitionState partition4 = taskState1.getPartitionsMap().get("token3");
+    // Assertions.assertEquals(partition4.getState(), PartitionStateEnum.FINISHED);
 
-        Assertions.assertEquals(taskState1.getSharedPartitions().size(), 2);
-        PartitionState partition5 = taskState1.getSharedPartitionsMap().get("token4");
-        Assertions.assertEquals(partition5.getState(), PartitionStateEnum.CREATED);
-        PartitionState partition6 = taskState1.getSharedPartitionsMap().get("token5");
-        Assertions.assertEquals(partition6.getState(), PartitionStateEnum.REMOVED);
+    // Assertions.assertEquals(taskState1.getSharedPartitions().size(), 2);
+    // PartitionState partition5 = taskState1.getSharedPartitionsMap().get("token4");
+    // Assertions.assertEquals(partition5.getState(), PartitionStateEnum.CREATED);
+    // PartitionState partition6 = taskState1.getSharedPartitionsMap().get("token5");
+    // Assertions.assertEquals(partition6.getState(), PartitionStateEnum.REMOVED);
 
-        TaskState taskState2 = mergedRebalanceAnswer.getCurrentTaskState();
-        Assertions.assertEquals(taskState2.getTaskUid(), "task2");
-        Assertions.assertEquals(taskState2.getPartitionsMap().size(), 4);
-        Assertions.assertEquals(taskState2.getSharedPartitionsMap().size(), 1);
+    // TaskState taskState2 = mergedRebalanceAnswer.getCurrentTaskState();
+    // Assertions.assertEquals(taskState2.getTaskUid(), "task2");
+    // Assertions.assertEquals(taskState2.getPartitionsMap().size(), 4);
+    // Assertions.assertEquals(taskState2.getSharedPartitionsMap().size(), 1);
 
-        TaskState taskState3 = mergedRebalanceAnswer.getTaskStates().get("task1");
-        Assertions.assertEquals(taskState3.getTaskUid(), "task1");
-        Assertions.assertEquals(taskState3.getPartitionsMap().size(), 2);
-        Assertions.assertEquals(taskState3.getSharedPartitionsMap().size(), 1);
-    }
+    // TaskState taskState3 = mergedRebalanceAnswer.getTaskStates().get("task1");
+    // Assertions.assertEquals(taskState3.getTaskUid(), "task1");
+    // Assertions.assertEquals(taskState3.getPartitionsMap().size(), 2);
+    // Assertions.assertEquals(taskState3.getSharedPartitionsMap().size(), 1);
+    // }
 
     void testMergeIncrementalAnswer() {
         TaskSyncContext taskSyncContext1 = buildTaskSyncContext1();
@@ -151,50 +149,50 @@ class SyncEventMergerTest {
         Assertions.assertEquals(taskState3.getSharedPartitionsMap().size(), 1);
     }
 
-    @Test
-    void testMergeEpochupdate() {
-        TaskSyncContext taskSyncContext1 = buildTaskSyncContext1();
-        TaskSyncContext taskSyncContext2 = buildTaskSyncContext2();
+    // @Test
+    // void testMergeEpochupdate() {
+    // TaskSyncContext taskSyncContext1 = buildTaskSyncContext1();
+    // TaskSyncContext taskSyncContext2 = buildTaskSyncContext2();
 
-        TaskSyncEvent syncEvent = taskSyncContext1.buildUpdateEpochTaskSyncEvent();
-        TaskSyncContext mergedEpochUpdate = mergeEpochUpdate(
-                taskSyncContext2, syncEvent);
+    // TaskSyncEvent syncEvent = taskSyncContext1.buildUpdateEpochTaskSyncEvent();
+    // TaskSyncContext mergedEpochUpdate = mergeEpochUpdate(
+    // taskSyncContext2, syncEvent);
 
-        Assertions.assertEquals("task2", mergedEpochUpdate.getTaskUid());
-        Assertions.assertEquals(2, mergedEpochUpdate.getTaskStates().size());
+    // Assertions.assertEquals("task2", mergedEpochUpdate.getTaskUid());
+    // Assertions.assertEquals(2, mergedEpochUpdate.getTaskStates().size());
 
-        Assertions.assertEquals("task2", mergedEpochUpdate.getTaskUid());
-        Assertions.assertEquals(2, mergedEpochUpdate.getTaskStates().size());
+    // Assertions.assertEquals("task2", mergedEpochUpdate.getTaskUid());
+    // Assertions.assertEquals(2, mergedEpochUpdate.getTaskStates().size());
 
-        TaskState taskState1 = mergedEpochUpdate.getTaskStates().get("task0");
-        Assertions.assertEquals(taskState1.getTaskUid(), "task0");
+    // TaskState taskState1 = mergedEpochUpdate.getTaskStates().get("task0");
+    // Assertions.assertEquals(taskState1.getTaskUid(), "task0");
 
-        Assertions.assertEquals(taskState1.getPartitionsMap().size(), 4);
-        PartitionState partition1 = taskState1.getPartitionsMap().get("token0");
-        Assertions.assertEquals(partition1.getState(), PartitionStateEnum.CREATED);
-        PartitionState partition2 = taskState1.getPartitionsMap().get("token1");
-        Assertions.assertEquals(partition2.getState(), PartitionStateEnum.REMOVED);
-        PartitionState partition3 = taskState1.getPartitionsMap().get("token2");
-        Assertions.assertEquals(partition3.getState(), PartitionStateEnum.RUNNING);
-        PartitionState partition4 = taskState1.getPartitionsMap().get("token3");
-        Assertions.assertEquals(partition4.getState(), PartitionStateEnum.FINISHED);
+    // Assertions.assertEquals(taskState1.getPartitionsMap().size(), 4);
+    // PartitionState partition1 = taskState1.getPartitionsMap().get("token0");
+    // Assertions.assertEquals(partition1.getState(), PartitionStateEnum.CREATED);
+    // PartitionState partition2 = taskState1.getPartitionsMap().get("token1");
+    // Assertions.assertEquals(partition2.getState(), PartitionStateEnum.REMOVED);
+    // PartitionState partition3 = taskState1.getPartitionsMap().get("token2");
+    // Assertions.assertEquals(partition3.getState(), PartitionStateEnum.RUNNING);
+    // PartitionState partition4 = taskState1.getPartitionsMap().get("token3");
+    // Assertions.assertEquals(partition4.getState(), PartitionStateEnum.FINISHED);
 
-        Assertions.assertEquals(taskState1.getSharedPartitions().size(), 2);
-        PartitionState partition5 = taskState1.getSharedPartitionsMap().get("token4");
-        Assertions.assertEquals(partition5.getState(), PartitionStateEnum.CREATED);
-        PartitionState partition6 = taskState1.getSharedPartitionsMap().get("token5");
-        Assertions.assertEquals(partition6.getState(), PartitionStateEnum.REMOVED);
+    // Assertions.assertEquals(taskState1.getSharedPartitions().size(), 2);
+    // PartitionState partition5 = taskState1.getSharedPartitionsMap().get("token4");
+    // Assertions.assertEquals(partition5.getState(), PartitionStateEnum.CREATED);
+    // PartitionState partition6 = taskState1.getSharedPartitionsMap().get("token5");
+    // Assertions.assertEquals(partition6.getState(), PartitionStateEnum.REMOVED);
 
-        TaskState taskState2 = mergedEpochUpdate.getCurrentTaskState();
-        Assertions.assertEquals(taskState2.getTaskUid(), "task2");
-        Assertions.assertEquals(taskState2.getPartitionsMap().size(), 4);
-        Assertions.assertEquals(taskState2.getSharedPartitionsMap().size(), 1);
+    // TaskState taskState2 = mergedEpochUpdate.getCurrentTaskState();
+    // Assertions.assertEquals(taskState2.getTaskUid(), "task2");
+    // Assertions.assertEquals(taskState2.getPartitionsMap().size(), 4);
+    // Assertions.assertEquals(taskState2.getSharedPartitionsMap().size(), 1);
 
-        TaskState taskState3 = mergedEpochUpdate.getTaskStates().get("task1");
-        Assertions.assertEquals(taskState3.getTaskUid(), "task1");
-        Assertions.assertEquals(taskState3.getPartitionsMap().size(), 2);
-        Assertions.assertEquals(taskState3.getSharedPartitionsMap().size(), 1);
-    }
+    // TaskState taskState3 = mergedEpochUpdate.getTaskStates().get("task1");
+    // Assertions.assertEquals(taskState3.getTaskUid(), "task1");
+    // Assertions.assertEquals(taskState3.getPartitionsMap().size(), 2);
+    // Assertions.assertEquals(taskState3.getSharedPartitionsMap().size(), 1);
+    // }
 
     private TaskSyncContext buildTaskSyncContext1() {
 

--- a/src/test/java/io/debezium/connector/spanner/task/SyncEventMergerTest.java
+++ b/src/test/java/io/debezium/connector/spanner/task/SyncEventMergerTest.java
@@ -29,7 +29,7 @@ class SyncEventMergerTest {
         TaskSyncContext taskSyncContext1 = buildTaskSyncContext1(RebalanceState.INITIAL_INCREMENTED_STATE_COMPLETED, false);
         TaskSyncContext taskSyncContext2 = buildTaskSyncContext2(RebalanceState.INITIAL_INCREMENTED_STATE_COMPLETED, true);
 
-        TaskSyncEvent rebalanceAnswer1 = taskSyncContext1.buildRebalanceAnswerTaskSyncEvent();
+        TaskSyncEvent rebalanceAnswer1 = taskSyncContext1.buildRebalanceAnswerTaskSyncEvent(0);
         TaskSyncContext mergedRebalanceAnswer = mergeRebalanceAnswer(
                 taskSyncContext2, rebalanceAnswer1);
 

--- a/src/test/java/io/debezium/connector/spanner/task/TaskSyncContextTest.java
+++ b/src/test/java/io/debezium/connector/spanner/task/TaskSyncContextTest.java
@@ -26,7 +26,7 @@ class TaskSyncContextTest {
         TaskState task0 = generateTaskStateWithPartitions(
                 "task0", List.of(), List.of());
 
-        TaskSyncEvent syncEvent = taskSyncContext.buildRebalanceAnswerTaskSyncEvent();
+        TaskSyncEvent syncEvent = taskSyncContext.buildRebalanceAnswerTaskSyncEvent(0);
 
         // Build rebalance answer.
         Assertions.assertEquals("task0", syncEvent.getTaskUid());
@@ -58,7 +58,7 @@ class TaskSyncContextTest {
         TaskState task0 = generateTaskStateWithPartitions(
                 "task0", List.of(), List.of());
 
-        TaskSyncEvent syncEvent = taskSyncContext.buildRebalanceAnswerTaskSyncEvent();
+        TaskSyncEvent syncEvent = taskSyncContext.buildRebalanceAnswerTaskSyncEvent(0);
 
         // Build rebalance answer.
         Assertions.assertEquals("task0", syncEvent.getTaskUid());


### PR DESCRIPTION
Make the connector robust against rebalance events:

(1) Ensure that all alive tasks in the connector process all previous NEW_EPOCH messages. We do this by only updating the rebalance generation ID when sending NEW_EPOCH messages and receiving NEW_EPOCH messages. Previously, we updated the rebalance generation ID whenever we received a rebalance event from Kafka. Since we skip NEW_EPOCH / REBALANCE_ANSWER / UDPATE_EPOCH messages with a stale rebalance generation ID, this caused some tasks to skip processing some previous NEW_EPOCH messages. This would cause the same partitions to get redistributed twice, causing partition duplication.

(2) Make sure we add a timeout when retrieving partition offsets when starting a change stream query. If we don't add a timeout, this could cause the task to get stuck for >20 minutes in TakePartitionForStreamingOperation. Since this method is called under a lock, this would cause the entire task processing to get stuck, causing increasing low watermark lag.

(3) Fix the leader rebalancing algorithm by making sure to not re-share partitions already shared to an alive task

(4) Currently we distribute all finished partitions from obsolete tasks to the leader. This can cause the RemoveFinishedPartitionOperation to be inordinately slow on the leader task, especially if the finished partition's child happened to be already removed. Fix this by decreasing the frequency of removing finished partition operation, and also removing finished partiitons if the children were already removed.