### PR TITLE
DBZ-6906 Add integration tests against Cloud Spanner emulator.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
@@ -35,6 +37,13 @@
         <docker.tag.name>latest</docker.tag.name>
         <docker.skip.push>true</docker.skip.push>
         <docker.repository.name>quay.io/debezium/kafka-spanner-connector</docker.repository.name>
+        <!--
+          Specify the properties that will be used for setting up the integration tests' Docker container.
+        -->
+        <docker.db>gcr.io/cloud-spanner-emulator/emulator</docker.db>
+        <docker.filter>${docker.db},${docker.repository.name}:${docker.tag.name}</docker.filter>
+        <docker.skip>false</docker.skip>
+        <docker.showLogs>true</docker.showLogs>
     </properties>
 
     <repositories>
@@ -149,7 +158,7 @@
                 <artifactId>protobuf-java</artifactId>
                 <version>${version.com.google.protobuf}</version>
             </dependency>
-            <!--<dependency>
+            <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
                 <version>${version.org.slf4j}</version>
@@ -158,7 +167,7 @@
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-simple</artifactId>
                 <version>${version.org.slf4j}</version>
-            </dependency>-->
+            </dependency>
             <dependency>
                 <groupId>com.datadoghq</groupId>
                 <artifactId>sketches-java</artifactId>
@@ -218,11 +227,17 @@
                 <artifactId>awaitility</artifactId>
                 <version>${version.awaitility}</version>
             </dependency>
+            <dependency>
+                <groupId>io.debezium</groupId>
+                <artifactId>debezium-embedded</artifactId>
+                <version>${version.debezium}</version>
+                <type>test-jar</type>
+                <scope>test</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
     <dependencies>
-
         <!-- Debezium artifacts -->
         <dependency>
             <groupId>io.debezium</groupId>
@@ -233,6 +248,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>connect-api</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
@@ -271,7 +287,7 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
 
-       <!-- Building -->
+        <!-- Building -->
         <dependency>
             <groupId>io.debezium</groupId>
             <artifactId>debezium-ide-configs</artifactId>
@@ -310,6 +326,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
@@ -332,6 +353,38 @@
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.debezium</groupId>
+            <artifactId>debezium-embedded</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.debezium</groupId>
+            <artifactId>debezium-embedded</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.debezium</groupId>
+            <artifactId>debezium-core</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-connect-avro-converter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -417,8 +470,127 @@
                     </execution>
                 </executions>
             </plugin>
-
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>integration-test</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>verify</id>
+                        <goals>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <skipTests>${skipITs}</skipTests>
+                    <enableAssertions>true</enableAssertions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <configuration>
+                    <watchInterval>500</watchInterval>
+                    <logDate>default</logDate>
+                    <verbose>true</verbose>
+                    <imagePullPolicy>IfNotPresent</imagePullPolicy>
+                    <images>
+                        <image>
+                            <name>${docker.db}</name>
+                            <run>
+                                <namingStrategy>none</namingStrategy>
+                                <ports>
+                                    <port>9010:9010</port>
+                                    <port>9020:9020</port>
+                                </ports>
+                                <log>
+                                    <prefix>cloud-spanner-emulator</prefix>
+                                    <enabled>true</enabled>
+                                    <color>yellow</color>
+                                </log>
+                                <wait>
+                                    <time>10000</time>
+                                    <log>Cloud Spanner Emulator running.</log>
+                                </wait>
+                            </run>
+                            <external>
+                                <type>properties</type>
+                                <mode>override</mode>
+                            </external>
+                        </image>
+                    </images>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>build</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                        <configuration>
+                            <repository>${docker.repository.name}</repository>
+                            <skip>${docker.skip.push}</skip>
+                            <images>
+                                <image>
+                                    <name>${docker.repository.name}:${docker.tag.name}</name>
+                                    <build>
+                                        <contextDir>${project.basedir}</contextDir>
+                                        <dockerFile>${project.basedir}/src/test/docker/Dockerfile</dockerFile>
+                                        <filter>@</filter>
+                                    </build>
+                                </image>
+                            </images>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>push</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>push</goal>
+                        </goals>
+                        <configuration>
+                            <repository>${docker.repository.name}</repository>
+                            <pushImage>true</pushImage>
+                            <skip>${docker.skip.push}</skip>
+                            <authConfig>
+                                <username>${docker.username}</username>
+                                <password>${docker.password}</password>
+                            </authConfig>
+                            <images>
+                                <image>
+                                    <name>${docker.repository.name}:${docker.tag.name}</name>
+                                    <build>
+                                        <contextDir>${project.basedir}</contextDir>
+                                        <dockerFile>${project.basedir}/src/test/docker/Dockerfile</dockerFile>
+                                        <filter>@</filter>
+                                    </build>
+                                </image>
+                            </images>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>start</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>start</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>stop</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>stop</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- <plugin>
                 <groupId>io.fabric8</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
                 <executions>
@@ -445,7 +617,7 @@
                         </image>
                     </images>
                 </configuration>
-            </plugin>
+            </plugin> -->
         </plugins>
         <resources>
             <!-- Apply the properties set in the POM to the resource files -->
@@ -458,6 +630,16 @@
                 </includes>
             </resource>
         </resources>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+                <filtering>true</filtering>
+                <includes>
+                    <include>*</include>
+                    <include>**/*</include>
+                </includes>
+            </testResource>
+        </testResources>
     </build>
 
     <profiles>
@@ -543,42 +725,55 @@
                             <argLine>${surefireArgLine} -Xmx1024m -noverify</argLine>
                         </configuration>
                     </plugin>
-                    <plugin>
+                    <!-- <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>default-integration-test</id>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
+                        <configuration>
+                            <printSummary>true</printSummary>
+                            <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                            <forkCount>3</forkCount>
+                            <reuseForks>true</reuseForks>
+                            <argLine>${surefireArgLine} -Xmx1024m -noverify</argLine>
+                        </configuration>
+                    </plugin> -->
                     <plugin>
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>
                         <version>${jacoco.version}</version>
                         <configuration>
                             <excludes>
-                                <exclude>io/debezium/connector/spanner/context/offset/SpannerOffsetContext.class</exclude>
-                                <exclude>io/debezium/connector/spanner/db/model/schema/ColumnType.class</exclude>
-                                <exclude>io/debezium/connector/spanner/db/model/StreamEventMetadata.class</exclude>
-                                <exclude>io/debezium/connector/spanner/db/stream/PartitionEventListener.class</exclude>
-                                <exclude>io/debezium/connector/spanner/db/stream/SpannerChangeStreamService.class</exclude>
+                                <exclude>
+                                    io/debezium/connector/spanner/context/offset/SpannerOffsetContext.class</exclude>
+                                <exclude>
+                                    io/debezium/connector/spanner/db/model/schema/ColumnType.class</exclude>
+                                <exclude>
+                                    io/debezium/connector/spanner/db/model/StreamEventMetadata.class</exclude>
+                                <exclude>
+                                    io/debezium/connector/spanner/db/stream/PartitionEventListener.class</exclude>
+                                <exclude>
+                                    io/debezium/connector/spanner/db/stream/SpannerChangeStreamService.class</exclude>
                                 <exclude>io/debezium/connector/spanner/metrics/SpannerMeter.class</exclude>
-                                <exclude>io/debezium/connector/spanner/metrics/jmx/SpannerMetricsMXBean.class</exclude>
-                                <exclude>io/debezium/connector/spanner/metrics/jmx/SpannerSnapshotChangeEventSourceMetricsStub.class</exclude>
-                                <exclude>io/debezium/connector/spanner/metrics/jmx/SpannerStreamingChangeEventSourceMetrics.class</exclude>
-                                <exclude>io/debezium/connector/spanner/schema/mapper/ColumnTypeSchemaMapper.class</exclude>
-                                <exclude>io/debezium/connector/spanner/schema/KafkaSpannerTableSchemaFactory.class</exclude>
-                                <exclude>io/debezium/connector/spanner/SpannerStreamingChangeEventSource.PartitionEventListener.class</exclude>
+                                <exclude>
+                                    io/debezium/connector/spanner/metrics/jmx/SpannerMetricsMXBean.class</exclude>
+                                <exclude>
+                                    io/debezium/connector/spanner/metrics/jmx/SpannerSnapshotChangeEventSourceMetricsStub.class</exclude>
+                                <exclude>
+                                    io/debezium/connector/spanner/metrics/jmx/SpannerStreamingChangeEventSourceMetrics.class</exclude>
+                                <exclude>
+                                    io/debezium/connector/spanner/schema/mapper/ColumnTypeSchemaMapper.class</exclude>
+                                <exclude>
+                                    io/debezium/connector/spanner/schema/KafkaSpannerTableSchemaFactory.class</exclude>
+                                <exclude>
+                                    io/debezium/connector/spanner/SpannerStreamingChangeEventSource.PartitionEventListener.class</exclude>
                                 <exclude>io/debezium/connector/spanner/SpannerErrorHandler.class</exclude>
                                 <exclude>io/debezium/connector/spanner/SpannerBaseSourceTask.class</exclude>
-                                <exclude>io/debezium/connector/spanner/SpannerSourceInfoStructMaker.class</exclude>
+                                <exclude>
+                                    io/debezium/connector/spanner/SpannerSourceInfoStructMaker.class</exclude>
                                 <exclude>io/debezium/connector/spanner/SpannerPartition.class</exclude>
-                                <exclude>io/debezium/connector/spanner/SpannerChangeEventSourceCoordinator.class</exclude>
-                                <exclude>io/debezium/connector/spanner/CommittingRecordsStreamingChangeEventSource.class</exclude>
+                                <exclude>
+                                    io/debezium/connector/spanner/SpannerChangeEventSourceCoordinator.class</exclude>
+                                <exclude>
+                                    io/debezium/connector/spanner/CommittingRecordsStreamingChangeEventSource.class</exclude>
                                 <exclude>io/debezium/connector/spanner/SpannerConnectorTask.class</exclude>
 
                                 <exclude>io/debezium/connector/spanner/config/validation/**</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -590,34 +590,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <!-- <plugin>
-                <groupId>io.fabric8</groupId>
-                <artifactId>docker-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>build</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>build</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <repository>${docker.repository.name}</repository>
-                    <pushImage>true</pushImage>
-                    <skip>${docker.skip.push}</skip>
-                    <images>
-                        <image>
-                            <name>${docker.repository.name}:${docker.tag.name}</name>
-                            <build>
-                                <contextDir>${project.basedir}</contextDir>
-                                <dockerFile>${project.basedir}/src/test/docker/Dockerfile</dockerFile>
-                                <filter>@</filter>
-                            </build>
-                        </image>
-                    </images>
-                </configuration>
-            </plugin> -->
         </plugins>
         <resources>
             <!-- Apply the properties set in the POM to the resource files -->

--- a/src/main/java/io/debezium/connector/spanner/config/validation/ConnectionValidator.java
+++ b/src/main/java/io/debezium/connector/spanner/config/validation/ConnectionValidator.java
@@ -83,6 +83,13 @@ public class ConnectionValidator implements ConfigurationValidator.Validator {
             result = false;
             return this;
         }
+
+        if (FieldValidator.isSpecified(host) && isAgainstEmulator) {
+            LOGGER.error(HOST_CONFLICT);
+            context.error(HOST_CONFLICT, SPANNER_HOST, SPANNER_EMULATOR_HOST);
+            result = false;
+            return this;
+        }
         return this;
     }
 

--- a/src/main/java/io/debezium/connector/spanner/config/validation/ConnectionValidator.java
+++ b/src/main/java/io/debezium/connector/spanner/config/validation/ConnectionValidator.java
@@ -84,12 +84,6 @@ public class ConnectionValidator implements ConfigurationValidator.Validator {
             return this;
         }
 
-        if (FieldValidator.isSpecified(host) && isAgainstEmulator) {
-            LOGGER.error(HOST_CONFLICT);
-            context.error(HOST_CONFLICT, SPANNER_HOST, SPANNER_EMULATOR_HOST);
-            result = false;
-            return this;
-        }
         return this;
     }
 

--- a/src/test/java/io/debezium/connector/spanner/AbstractSpannerConnectorIT.java
+++ b/src/test/java/io/debezium/connector/spanner/AbstractSpannerConnectorIT.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.spanner;
+
+import org.junit.jupiter.api.AfterAll;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.spanner.util.Connection;
+import io.debezium.connector.spanner.util.Database;
+import io.debezium.connector.spanner.util.KafkaEnvironment;
+import io.debezium.embedded.AbstractConnectorTest;
+
+public class AbstractSpannerConnectorIT extends AbstractConnectorTest {
+
+    private static final KafkaEnvironment KAFKA_ENVIRONMENT = new KafkaEnvironment(
+            KafkaEnvironment.DOCKER_COMPOSE_FILE);
+    protected static final Database database = Database.TEST_DATABASE;
+    protected static final Connection databaseConnection = database.getConnection();
+    protected static final int WAIT_FOR_CDC = 1000;
+
+    static {
+        if (!KAFKA_ENVIRONMENT.isStarted()) {
+            KAFKA_ENVIRONMENT.start();
+            KAFKA_ENVIRONMENT.setStarted();
+        }
+    }
+
+    protected static final Configuration baseConfig = Configuration.create()
+            .with("gcp.spanner.instance.id", database.getInstanceId())
+            .with("gcp.spanner.project.id", database.getProjectId())
+            .with("gcp.spanner.database.id", database.getDatabaseId())
+            .with("gcp.spanner.emulator.host",
+                    "http://localhost:9010")
+            .with("offset.storage", "org.apache.kafka.connect.storage.MemoryOffsetBackingStore")
+            .with("connector.spanner.sync.kafka.bootstrap.servers", KAFKA_ENVIRONMENT.kafkaBrokerApiOn().getAddress())
+            .with("database.history.kafka.bootstrap.servers", KAFKA_ENVIRONMENT.kafkaBrokerApiOn().getAddress())
+            .with("bootstrap.servers", KAFKA_ENVIRONMENT.kafkaBrokerApiOn().getAddress())
+            .with("heartbeat.interval.ms", "300000")
+            .with("gcp.spanner.low-watermark.enabled", false)
+            .build();
+
+    @AfterAll
+    public static void after() throws InterruptedException {
+        System.out.println("Cleaning up kafka...");
+        KAFKA_ENVIRONMENT.clearTopics();
+        System.out.println("Cleaning complete!");
+    }
+
+    protected static void waitForCDC() {
+        try {
+            Thread.sleep(WAIT_FOR_CDC);
+        }
+        catch (Exception e) {
+
+        }
+    }
+
+    protected String getTopicName(Configuration config, String tableName) {
+        String debeziumConnectorName = "testing-connector";
+        return debeziumConnectorName + "." + tableName;
+    }
+}

--- a/src/test/java/io/debezium/connector/spanner/BasicSanityCheckIT.java
+++ b/src/test/java/io/debezium/connector/spanner/BasicSanityCheckIT.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.spanner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.config.Configuration;
+
+public class BasicSanityCheckIT extends AbstractSpannerConnectorIT {
+
+    private static final String tableName = "embedded_sanity_tests_table";
+    private static final String changeStreamName = "embeddedSanityTestChangeStream";
+
+    @BeforeAll
+    static void setup() throws InterruptedException, ExecutionException {
+        databaseConnection.createTable(tableName + "(id int64, name string(100)) primary key(id)");
+        databaseConnection.createChangeStream(changeStreamName, tableName);
+
+        System.out.println("BasicSanityCheckIT is ready...");
+    }
+
+    @AfterAll
+    static void clear() throws InterruptedException {
+        databaseConnection.dropChangeStream(changeStreamName);
+        databaseConnection.dropTable(tableName);
+    }
+
+    @Test
+    public void shouldNotStartConnectorWithoutRequireConfigs() throws InterruptedException {
+        // Config with only instance id provided.
+        Configuration config = Configuration.create()
+                .with("gcp.spanner.instance.id", database.getInstanceId())
+                .build();
+        start(SpannerConnector.class, config, (success, msg, error) -> {
+            assertThat(success).isFalse();
+            assertThat(msg.contains("Connector configuration is not valid"));
+        });
+        assertConnectorNotRunning();
+    }
+
+    @Test
+    public void shouldNotStartConnectorWithoutNonExistentChangeStreams() throws InterruptedException {
+        final Configuration config = Configuration.copy(baseConfig)
+                .with("gcp.spanner.change.stream", "fooBar")
+                .with("name", tableName + "_test")
+                .with("gcp.spanner.start.time",
+                        DateTimeFormatter.ISO_INSTANT.format(Instant.now()))
+                .build();
+        start(SpannerConnector.class, config, (success, msg, error) -> {
+            assertThat(success).isFalse();
+        });
+        assertConnectorNotRunning();
+    }
+
+    @Test
+    public void shouldNotStartConnectorWithOutOfRangeHeartbeatMillis() throws InterruptedException {
+        final Configuration config = Configuration.copy(baseConfig)
+                .with("gcp.spanner.change.stream", changeStreamName)
+                .with("heartbeat.interval.ms", "1")
+                .with("gcp.spanner.start.time",
+                        DateTimeFormatter.ISO_INSTANT.format(Instant.now().plus(2, ChronoUnit.DAYS)))
+                .build();
+        start(SpannerConnector.class, config, (success, msg, error) -> {
+            assertThat(success).isFalse();
+            assertThat(msg.contains("Heartbeat interval must be between 100 and 300000"));
+        });
+        assertConnectorNotRunning();
+    }
+
+    @Test
+    public void shouldStreamUpdatesToKafka() throws InterruptedException {
+        System.out.println("test hahahaha");
+        final Configuration config = Configuration.copy(baseConfig)
+                .with("gcp.spanner.change.stream", changeStreamName)
+                .with("name", tableName + "_test")
+                .with("gcp.spanner.start.time",
+                        DateTimeFormatter.ISO_INSTANT.format(Instant.now()))
+                .build();
+        initializeConnectorTestFramework();
+        start(SpannerConnector.class, config);
+        assertConnectorIsRunning();
+        databaseConnection.executeUpdate("insert into " + tableName + "(id, name) values (1, 'some name')");
+        databaseConnection.executeUpdate("update " + tableName + " set name = 'test' where id = 1");
+        databaseConnection.executeUpdate("delete from " + tableName + " where id = 1");
+        waitForCDC();
+        SourceRecords sourceRecords = consumeRecordsByTopic(10, false);
+        List<SourceRecord> records = sourceRecords.recordsForTopic(getTopicName(config, tableName));
+        assertThat(records).hasSize(4); // insert + update + delete + TOMBSTONE
+        stopConnector();
+        assertConnectorNotRunning();
+    }
+}

--- a/src/test/java/io/debezium/connector/spanner/BasicSanityCheckIT.java
+++ b/src/test/java/io/debezium/connector/spanner/BasicSanityCheckIT.java
@@ -12,6 +12,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
@@ -97,7 +98,7 @@ public class BasicSanityCheckIT extends AbstractSpannerConnectorIT {
         databaseConnection.executeUpdate("insert into " + tableName + "(id, name) values (1, 'some name')");
         databaseConnection.executeUpdate("update " + tableName + " set name = 'test' where id = 1");
         databaseConnection.executeUpdate("delete from " + tableName + " where id = 1");
-        waitForCDC();
+        waitForAvailableRecords(waitTimeForRecords(), TimeUnit.SECONDS);
         SourceRecords sourceRecords = consumeRecordsByTopic(10, false);
         List<SourceRecord> records = sourceRecords.recordsForTopic(getTopicName(config, tableName));
         assertThat(records).hasSize(4);

--- a/src/test/java/io/debezium/connector/spanner/GracefulRestartIT.java
+++ b/src/test/java/io/debezium/connector/spanner/GracefulRestartIT.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.spanner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.config.Configuration;
+
+public class GracefulRestartIT extends AbstractSpannerConnectorIT {
+
+    private static final String tableName = "graceful_restart_tests_table";
+    private static final String changeStreamName = "gracefulRestartChangeStream";
+
+    @BeforeAll
+    static void setup() throws InterruptedException, ExecutionException {
+        databaseConnection.createTable(tableName + "(id int64, name string(100)) primary key(id)");
+        databaseConnection.createChangeStream(changeStreamName, tableName);
+
+        System.out.println("GracefulRestartIT is ready...");
+    }
+
+    @AfterAll
+    static void clear() throws InterruptedException {
+        databaseConnection.dropChangeStream(changeStreamName);
+        databaseConnection.dropTable(tableName);
+    }
+
+    @Test
+    public void checkUpdatesStreamedToKafka() throws InterruptedException {
+        stopConnector();
+        final Configuration config = Configuration.copy(baseConfig)
+                .with("gcp.spanner.change.stream", changeStreamName)
+                .with("name", tableName + "_test")
+                .with("gcp.spanner.start.time",
+                        DateTimeFormatter.ISO_INSTANT.format(Instant.now()))
+                .build();
+        initializeConnectorTestFramework();
+        start(SpannerConnector.class, config);
+        assertConnectorIsRunning();
+        databaseConnection.executeUpdate("insert into " + tableName + "(id, name) values (1, 'some name')");
+        SourceRecords sourceRecords = consumeRecordsByTopic(5, false);
+        List<SourceRecord> records = sourceRecords.recordsForTopic(getTopicName(config, tableName));
+        assertThat(records).hasSize(1); // insert
+        stopConnector();
+        assertConnectorNotRunning();
+        databaseConnection.executeUpdate("update " + tableName + " set name = 'test' where id = 1");
+        start(SpannerConnector.class, config);
+        SourceRecords sourceRecords2 = consumeRecordsByTopic(10, false);
+        List<SourceRecord> records2 = sourceRecords2.recordsForTopic(getTopicName(config, tableName));
+        assertThat(records2).hasSizeGreaterThanOrEqualTo(1); // insert + update
+        stopConnector();
+        assertConnectorNotRunning();
+    }
+}

--- a/src/test/java/io/debezium/connector/spanner/KafkaTopicPartitionIT.java
+++ b/src/test/java/io/debezium/connector/spanner/KafkaTopicPartitionIT.java
@@ -14,6 +14,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import org.apache.kafka.connect.data.Struct;
@@ -23,6 +24,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import io.debezium.config.Configuration;
+import io.debezium.util.Testing;
 
 public class KafkaTopicPartitionIT extends AbstractSpannerConnectorIT {
 
@@ -38,7 +40,7 @@ public class KafkaTopicPartitionIT extends AbstractSpannerConnectorIT {
 
         databaseConnection.createChangeStream(changeStreamName, tableName);
 
-        System.out.println("KafkaTopicPartitionIT is ready...");
+        Testing.print("KafkaTopicPartitionIT is ready...");
     }
 
     @AfterAll
@@ -62,7 +64,7 @@ public class KafkaTopicPartitionIT extends AbstractSpannerConnectorIT {
         databaseConnection.executeUpdate("update " + tableName + " set name = 'test' where id = 1");
         databaseConnection.executeUpdate("insert into " + tableName + "(id, name) values (2, 'test name')");
         databaseConnection.executeUpdate("update " + tableName + " set bool = true where id = 2");
-        waitForCDC();
+        waitForAvailableRecords(waitTimeForRecords(), TimeUnit.SECONDS);
         SourceRecords sourceRecords = consumeRecordsByTopic(10, false);
         List<SourceRecord> records = sourceRecords.recordsForTopic(getTopicName(config, tableName));
         assertThat(records).hasSize(4); // 2 * (insert + update)

--- a/src/test/java/io/debezium/connector/spanner/KafkaTopicPartitionIT.java
+++ b/src/test/java/io/debezium/connector/spanner/KafkaTopicPartitionIT.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.spanner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.config.Configuration;
+
+public class KafkaTopicPartitionIT extends AbstractSpannerConnectorIT {
+
+    private static final String tableName = "kafka_topic_partition_tests_table";
+    private static final String changeStreamName = "kafkaTopicPartitionChangeStream";
+
+    @BeforeAll
+    static void setup() throws InterruptedException, ExecutionException {
+        databaseConnection.createTable(tableName + "(id int64, name string(100),time TIMESTAMP,\n" +
+                "  date DATE,\n" +
+                "  byt BYTES(2000),\n" +
+                "  bool BOOL, long_time int64) primary key(id)");
+
+        databaseConnection.createChangeStream(changeStreamName, tableName);
+
+        System.out.println("KafkaTopicPartitionIT is ready...");
+    }
+
+    @AfterAll
+    static void clear() throws InterruptedException {
+        databaseConnection.dropChangeStream(changeStreamName);
+        databaseConnection.dropTable(tableName);
+    }
+
+    @Test
+    public void checkRecordsWithSameKeyAreInSamePartition() throws InterruptedException {
+        final Configuration config = Configuration.copy(baseConfig)
+                .with("gcp.spanner.change.stream", changeStreamName)
+                .with("name", tableName + "_test")
+                .with("gcp.spanner.start.time",
+                        DateTimeFormatter.ISO_INSTANT.format(Instant.now()))
+                .build();
+        initializeConnectorTestFramework();
+        start(SpannerConnector.class, config);
+        assertConnectorIsRunning();
+        databaseConnection.executeUpdate("insert into " + tableName + "(id, name) values (1, 'some name')");
+        databaseConnection.executeUpdate("update " + tableName + " set name = 'test' where id = 1");
+        databaseConnection.executeUpdate("insert into " + tableName + "(id, name) values (2, 'test name')");
+        databaseConnection.executeUpdate("update " + tableName + " set bool = true where id = 2");
+        waitForCDC();
+        SourceRecords sourceRecords = consumeRecordsByTopic(10, false);
+        List<SourceRecord> records = sourceRecords.recordsForTopic(getTopicName(config, tableName));
+        assertThat(records).hasSize(4); // 2 * (insert + update)
+        Map<Object, List<SourceRecord>> keyToRecords = records.stream()
+                .collect(Collectors.groupingBy(SourceRecord::key));
+        keyToRecords.values().forEach(keyRecordsGroup -> {
+            assertEquals(2, keyRecordsGroup.size());
+            SourceRecord record1 = keyRecordsGroup.get(0);
+            SourceRecord record2 = keyRecordsGroup.get(1);
+            long commitTimestamp1 = (Long) ((Struct) (record1.value())).get("ts_ms");
+            long commitTimestamp2 = (Long) ((Struct) (record2.value())).get("ts_ms");
+            assertTrue(commitTimestamp1 <= commitTimestamp2);
+            assertEquals(1, keyRecordsGroup.stream()
+                    .map(SourceRecord::sourcePartition)
+                    .collect(Collectors.toSet()).size());
+        });
+        stopConnector();
+        assertConnectorNotRunning();
+    }
+
+}

--- a/src/test/java/io/debezium/connector/spanner/KafkaTopicPartitionIT.java
+++ b/src/test/java/io/debezium/connector/spanner/KafkaTopicPartitionIT.java
@@ -68,6 +68,7 @@ public class KafkaTopicPartitionIT extends AbstractSpannerConnectorIT {
         assertThat(records).hasSize(4); // 2 * (insert + update)
         Map<Object, List<SourceRecord>> keyToRecords = records.stream()
                 .collect(Collectors.groupingBy(SourceRecord::key));
+        assertThat(keyToRecords).hasSize(2);
         keyToRecords.values().forEach(keyRecordsGroup -> {
             assertEquals(2, keyRecordsGroup.size());
             SourceRecord record1 = keyRecordsGroup.get(0);

--- a/src/test/java/io/debezium/connector/spanner/LowWatermarkRecordIT.java
+++ b/src/test/java/io/debezium/connector/spanner/LowWatermarkRecordIT.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.spanner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.config.Configuration;
+
+public class LowWatermarkRecordIT extends AbstractSpannerConnectorIT {
+
+    private static final String tableName = "low_watermark_record_tests_table";
+    private static final String changeStreamName = "lowWatermarkRecordTestChangeStream";
+
+    @BeforeAll
+    static void setup() throws InterruptedException, ExecutionException {
+        databaseConnection.createTable(tableName + "(id int64, name string(100)) primary key(id)");
+        databaseConnection.createChangeStream(changeStreamName, tableName);
+
+        System.out.println("LowWatermarkRecordIT is ready...");
+    }
+
+    @AfterAll
+    static void clear() throws InterruptedException {
+        databaseConnection.dropChangeStream(changeStreamName);
+        databaseConnection.dropTable(tableName);
+    }
+
+    @Test
+    public void shouldStreamUpdatesToKafka() throws InterruptedException {
+        Instant now = Instant.now();
+        final Configuration config = Configuration.copy(baseConfig)
+                .with("gcp.spanner.change.stream", changeStreamName)
+                .with("name", tableName + "_test")
+                .with("gcp.spanner.start.time",
+                        DateTimeFormatter.ISO_INSTANT.format(now))
+                .with("gcp.spanner.low-watermark.enabled", true)
+                .build();
+        initializeConnectorTestFramework();
+        start(SpannerConnector.class, config);
+        assertConnectorIsRunning();
+        databaseConnection.executeUpdate("insert into " + tableName + "(id, name) values (1, 'some name')");
+        databaseConnection.executeUpdate("update " + tableName + " set name = 'test' where id = 1");
+        waitForCDC();
+        SourceRecords sourceRecords = consumeRecordsByTopic(10, false);
+        List<SourceRecord> records = sourceRecords.recordsForTopic(getTopicName(config, tableName));
+        List<Long> lowWatermarks = records.stream()
+                .map(rec -> rec.value() != null
+                        ? (Long) ((Struct) ((Struct) rec.value()).get("source")).get("low_watermark")
+                        : null)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+        assertThat(!lowWatermarks.isEmpty());
+        assertThat(Collections.max(lowWatermarks) > now.plus(2,
+                ChronoUnit.SECONDS).toEpochMilli());
+        validateLowWatermarks(records, lowWatermarks);
+        stopConnector();
+        assertConnectorNotRunning();
+    }
+
+    private void validateLowWatermarks(List<SourceRecord> records, List<Long> lowWatermarks) {
+        for (SourceRecord record : records) {
+            if (record.timestamp() != null) {
+                assertTrue(record.timestamp().longValue() > lowWatermarks.get(0).longValue());
+            }
+        }
+    }
+}

--- a/src/test/java/io/debezium/connector/spanner/util/Connection.java
+++ b/src/test/java/io/debezium/connector/spanner/util/Connection.java
@@ -1,0 +1,325 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.spanner.util;
+
+import static org.awaitility.Awaitility.await;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.api.gax.longrunning.OperationFuture;
+import com.google.cloud.NoCredentials;
+import com.google.cloud.spanner.DatabaseAdminClient;
+import com.google.cloud.spanner.DatabaseClient;
+import com.google.cloud.spanner.DatabaseId;
+import com.google.cloud.spanner.Dialect;
+import com.google.cloud.spanner.Instance;
+import com.google.cloud.spanner.InstanceConfigId;
+import com.google.cloud.spanner.InstanceId;
+import com.google.cloud.spanner.InstanceInfo;
+import com.google.cloud.spanner.ResultSet;
+import com.google.cloud.spanner.Spanner;
+import com.google.cloud.spanner.SpannerOptions;
+import com.google.cloud.spanner.Statement;
+import com.google.spanner.admin.database.v1.CreateDatabaseMetadata;
+import com.google.spanner.admin.database.v1.UpdateDatabaseDdlMetadata;
+import com.google.spanner.admin.instance.v1.CreateInstanceMetadata;
+
+import io.debezium.connector.spanner.db.dao.SchemaDao;
+
+public class Connection {
+
+    private static final Logger LOG = LoggerFactory.getLogger(Connection.class);
+
+    private final String projectId;
+    private final String instanceId;
+    private final String databaseId;
+    public static final String emulatorHost = "http://localhost:9010";
+
+    public DatabaseClient databaseClient;
+    private Spanner spanner;
+    private SchemaDao schemaDao;
+    private final Dialect dialect;
+
+    protected Connection(Database database) {
+        this.projectId = database.getProjectId();
+        this.instanceId = database.getInstanceId();
+        this.databaseId = database.getDatabaseId();
+        this.dialect = database.getDialect();
+    }
+
+    public ResultSet executeSelect(String query) {
+        return databaseClient.singleUse().executeQuery(Statement.of(query));
+    }
+
+    public ResultSet executeSelect(Statement statement) {
+        return databaseClient.singleUse().executeQuery(statement);
+    }
+
+    public Long executeUpdate(String query) {
+        final String msg = "Execution result: {}, query: {}";
+        return databaseClient.readWriteTransaction()
+                .run(transaction -> {
+                    final var uuid = UUID.randomUUID().toString();
+                    LOG.info("Begin transaction {}", uuid);
+                    final var res = transaction.executeUpdate(Statement.of(query));
+                    if (res > 0L) {
+                        LOG.info(msg, res, query);
+                    }
+                    else {
+                        LOG.warn(msg, res, query);
+                    }
+                    return res;
+                });
+    }
+
+    public Long executeUpdate(List<String> queries) {
+        final String msg = "Execution result: {}, query: {}";
+        return databaseClient.readWriteTransaction()
+                .run(transaction -> {
+                    final var uuid = UUID.randomUUID().toString();
+                    LOG.info("Begin transaction {}", uuid);
+                    var result = 0L;
+                    for (final var query : queries) {
+                        final var res = transaction.executeUpdate(Statement.of(query));
+                        result += res;
+                        if (res > 0L) {
+                            LOG.info(msg, res, query);
+                        }
+                        else {
+                            LOG.warn(msg, res, query);
+                        }
+                    }
+                    LOG.info("End transaction {}, result : {}", uuid, result);
+                    return result;
+                });
+    }
+
+    public void updateDDL(Iterable<String> updates) throws ExecutionException, InterruptedException {
+        OperationFuture<Void, UpdateDatabaseDdlMetadata> future = spanner.getDatabaseAdminClient()
+                .updateDatabaseDdl(instanceId, databaseId, updates, null);
+        future.get();
+    }
+
+    public void createTable(String tableDefinition) throws ExecutionException, InterruptedException {
+        this.updateDDL(List.of("create table " + tableDefinition));
+    }
+
+    public void createChangeStream(String changeStreamName, String... tables) throws ExecutionException,
+            InterruptedException {
+        this.updateDDL(List.of("create change stream " + changeStreamName + " for " +
+                (tables.length == 0 ? "ALL" : String.join(",", tables))));
+        await().atMost(Duration.ofSeconds(60)).until(() -> isStreamExist(changeStreamName));
+    }
+
+    public void createChangeStreamNewValue(String changeStreamName, String... tables) throws ExecutionException,
+            InterruptedException {
+        this.updateDDL(List.of("create change stream " + changeStreamName + " for " +
+                (tables.length == 0 ? "ALL" : String.join(",", tables)) +
+                " OPTIONS (\n" +
+                "            value_capture_type = 'NEW_VALUES'\n" +
+                "        ) "));
+        await().atMost(Duration.ofSeconds(60)).until(() -> isStreamExist(changeStreamName));
+    }
+
+    public void createChangeStreamNewRow(String changeStreamName, String... tables) throws ExecutionException,
+            InterruptedException {
+        this.updateDDL(List.of("create change stream " + changeStreamName + " for " +
+                (tables.length == 0 ? "ALL" : String.join(",", tables)) +
+                " OPTIONS (\n" +
+                "            value_capture_type = 'NEW_ROW'\n" +
+                "        ) "));
+        await().atMost(Duration.ofSeconds(60)).until(() -> isStreamExist(changeStreamName));
+    }
+
+    private String createInstance() {
+        for (Instance value : this.spanner.getInstanceAdminClient().listInstances().iterateAll()) {
+            if (value.getId().getInstance().equals("test-instance")) {
+                return "test-instance";
+            }
+        }
+        String configId = "regional-us-central1";
+        String displayName = "For IT";
+        int nodeCount = 1;
+        InstanceInfo instanceInfo = InstanceInfo.newBuilder(InstanceId.of(projectId, "test-instance"))
+                .setInstanceConfigId(InstanceConfigId.of(projectId, configId))
+                .setNodeCount(nodeCount)
+                .setDisplayName(displayName)
+                .build();
+
+        OperationFuture<Instance, CreateInstanceMetadata> instance = this.spanner.getInstanceAdminClient()
+                .createInstance(instanceInfo);
+        try {
+            instance.get();
+        }
+        catch (InterruptedException | ExecutionException e) {
+            throw new RuntimeException(e);
+        }
+        return "test-instance";
+    }
+
+    private boolean isStreamExist(String streamName) {
+        Statement statement;
+        if (schemaDao.isPostgres()) {
+            statement = Statement.newBuilder("select change_stream_name " +
+                    "from information_schema.change_streams cs " +
+                    "where cs.change_stream_name = $1")
+                    .bind("p1")
+                    .to(streamName.toLowerCase())
+                    .build();
+        }
+        else {
+            statement = Statement.newBuilder("select change_stream_name " +
+                    "from information_schema.change_streams cs " +
+                    "where cs.change_stream_name = @streamname")
+                    .bind("streamName")
+                    .to(streamName).build();
+        }
+        return databaseClient.singleUse().executeQuery(statement).next();
+    }
+
+    public boolean dropTable(String tableName) throws InterruptedException {
+        try {
+            if (!isTableExist(tableName)) {
+                return false;
+            }
+            this.updateDDL(List.of("drop table " + tableName));
+        }
+        catch (ExecutionException ex) {
+            LOG.warn("Can`t drop table", ex);
+            return false;
+        }
+        return true;
+    }
+
+    public boolean dropChangeStream(String changeStreamName) throws InterruptedException {
+        try {
+            if (!this.isChangeStreamExist(changeStreamName)) {
+                return false;
+            }
+            this.updateDDL(List.of("drop change stream " + changeStreamName));
+
+        }
+        catch (ExecutionException ex) {
+            LOG.warn("Can`t delete change stream", ex);
+            return false;
+        }
+        return true;
+    }
+
+    public boolean isChangeStreamExist(String changeStreamName) {
+        Statement statement;
+        if (schemaDao.isPostgres()) {
+            statement = Statement.newBuilder("select * from information_schema.change_streams " +
+                    "where change_stream_name = $1")
+                    .bind("p1").to(changeStreamName).build();
+        }
+        else {
+            statement = Statement.newBuilder("select * from information_schema.change_streams " +
+                    "where change_stream_name = @streamName")
+                    .bind("streamName").to(changeStreamName).build();
+        }
+        try (ResultSet resultSet = this.executeSelect(statement)) {
+            return resultSet.next();
+        }
+    }
+
+    public boolean isTableExist(String tableName) {
+        Statement statement;
+        if (schemaDao.isPostgres()) {
+            statement = Statement
+                    .newBuilder(
+                            "select * from information_schema.tables where table_schema = '' and table_catalog = '' " +
+                                    "and table_name = $1")
+                    .bind("p1").to(tableName).build();
+        }
+        else {
+            statement = Statement
+                    .newBuilder(
+                            "select * from information_schema.tables where table_schema = '' and table_catalog = '' " +
+                                    "and table_name = @tableName")
+                    .bind("tableName").to(tableName).build();
+        }
+        try (ResultSet resultSet = this.executeSelect(statement)) {
+            return resultSet.next();
+        }
+    }
+
+    public boolean isDatabaseExist(String databaseId) {
+        try {
+            return this.spanner.getDatabaseAdminClient().getDatabase(instanceId, databaseId) != null;
+        }
+        catch (Exception ex) {
+            return false;
+        }
+    }
+
+    public void dropDatabase(String databaseId) {
+        this.spanner.getDatabaseAdminClient().dropDatabase(instanceId, databaseId);
+        LOG.info("{} database has been dropped", databaseId);
+    }
+
+    public void createDatabase(String databaseId, Dialect dialect) throws InterruptedException {
+        createInstance();
+        DatabaseAdminClient dbAdminClient = this.spanner.getDatabaseAdminClient();
+        OperationFuture<com.google.cloud.spanner.Database, CreateDatabaseMetadata> operationFuture = dbAdminClient
+                .createDatabase(
+                        dbAdminClient.newDatabaseBuilder(DatabaseId.of(projectId, instanceId, databaseId))
+                                .setDialect(dialect).build(),
+                        Collections.emptyList());
+        try {
+            operationFuture.get();
+        }
+        catch (ExecutionException ex) {
+            throw new RuntimeException("Failed to create database", ex);
+        }
+        LOG.info("{} database has been created", databaseId);
+    }
+
+    public Connection connect(Dialect dialect) throws InterruptedException {
+        if (this.databaseClient != null) {
+            return this;
+        }
+
+        this.init();
+
+        if (isDatabaseExist(databaseId)) {
+            this.dropDatabase(databaseId);
+        }
+
+        this.createDatabase(databaseId, dialect);
+
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> this.dropDatabase(databaseId)));
+
+        this.databaseClient = this.spanner.getDatabaseClient(DatabaseId.of(projectId, instanceId, databaseId));
+        this.schemaDao = new SchemaDao(databaseClient);
+
+        return this;
+    }
+
+    private void init() {
+        SpannerOptions.Builder builder = SpannerOptions.newBuilder();
+
+        builder.setCredentials(NoCredentials.getInstance());
+        builder.setProjectId(projectId);
+        builder.setEmulatorHost(emulatorHost);
+
+        SpannerOptions options = builder.build();
+        try {
+            this.spanner = options.getService();
+        }
+        catch (Throwable e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/io/debezium/connector/spanner/util/Database.java
+++ b/src/test/java/io/debezium/connector/spanner/util/Database.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.spanner.util;
+
+import java.util.UUID;
+
+import com.google.cloud.spanner.Dialect;
+
+public class Database {
+
+    private static final String projectId = "test-project";
+    private static final String instanceId = "test-instance";
+    private final String databaseId;
+
+    private Connection connection;
+
+    private final Dialect dialect;
+
+    private Database(String databaseId, Dialect dialect) {
+        this.databaseId = databaseId;
+        this.dialect = dialect;
+    }
+
+    public static final Database TEST_DATABASE = Database.builder()
+            .generateDatabaseId()
+            .build();
+
+    public String getProjectId() {
+        return projectId;
+    }
+
+    public String getInstanceId() {
+        return instanceId;
+    }
+
+    public String getDatabaseId() {
+        return databaseId;
+    }
+
+    public Dialect getDialect() {
+        return dialect;
+    }
+
+    public Connection getConnection() {
+        if (this.connection != null) {
+            return this.connection;
+        }
+        try {
+            this.connection = new Connection(this).connect(dialect);
+        }
+        catch (Exception ex) {
+            ex.printStackTrace();
+            Thread.currentThread().interrupt();
+        }
+        return this.connection;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private String databaseId;
+
+        private Dialect dialect = Dialect.GOOGLE_STANDARD_SQL;
+
+        public Builder dialect(Dialect dialect) {
+            this.dialect = dialect;
+            return this;
+        }
+
+        public Builder databaseId(String databaseId) {
+            this.databaseId = databaseId;
+            return this;
+        }
+
+        public Builder generateDatabaseId() {
+            String uuid = UUID.randomUUID().toString().replace("-", "")
+                    .substring(0, 8);
+            this.databaseId = "int_tests_" + uuid;
+            return this;
+        }
+
+        public Database build() {
+            return new Database(databaseId, dialect);
+        }
+    }
+}

--- a/src/test/java/io/debezium/connector/spanner/util/KafkaBrokerApi.java
+++ b/src/test/java/io/debezium/connector/spanner/util/KafkaBrokerApi.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.spanner.util;
+
+import java.util.Properties;
+
+import org.apache.avro.generic.GenericRecord;
+import org.apache.commons.lang3.SerializationUtils;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.connect.json.JsonDeserializer;
+import org.testcontainers.containers.ContainerState;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import io.confluent.kafka.serializers.KafkaAvroDeserializer;
+import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig;
+
+public class KafkaBrokerApi<K, V> {
+
+    protected static final String SCHEMA_REGISTRY_PORT = "8081";
+
+    protected static final String SCHEMA_REGISTRY_HOST = "http://localhost";
+
+    protected static final int POLL_DURATION_MILLIS = 100;
+
+    protected static final int WAIT_TOPIC_HAS_NO_MORE_RECORDS_SECONDS = 60;
+
+    public static final int POLL_FIRST_RECORDS_TIMEOUT_MAX_MINUTES = 10;
+
+    private final ContainerState containerState;
+
+    private final int kafkaPort;
+
+    private final Properties properties;
+
+    public KafkaBrokerApi(ContainerState containerState, int kafkaPort, Properties properties) {
+        this.containerState = containerState;
+        this.kafkaPort = kafkaPort;
+        this.properties = SerializationUtils.clone(properties);
+    }
+
+    public static String getSchemaRegistryAddress() {
+        return SCHEMA_REGISTRY_HOST + ":" + SCHEMA_REGISTRY_PORT;
+    }
+
+    public static KafkaBrokerApi<GenericRecord, GenericRecord> createKafkaBrokerApiGenericRecord(
+                                                                                                 ContainerState containerState, int kafkaPort) {
+        final Properties props = new Properties();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, containerState.getHost() + ":" + kafkaPort);
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, KafkaAvroDeserializer.class.getName());
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, KafkaAvroDeserializer.class.getName());
+        props.put(KafkaAvroDeserializerConfig.SCHEMA_REGISTRY_URL_CONFIG, getSchemaRegistryAddress());
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        props.put(KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG, false);
+        return new KafkaBrokerApi<>(containerState, kafkaPort, props);
+    }
+
+    public static KafkaBrokerApi<ObjectNode, ObjectNode> createKafkaBrokerApiObjectNode(ContainerState containerState,
+                                                                                        int kafkaPort) {
+        final Properties props = new Properties();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, containerState.getHost() + ":" + kafkaPort);
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class.getName());
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class.getName());
+        props.put(KafkaAvroDeserializerConfig.SCHEMA_REGISTRY_URL_CONFIG, getSchemaRegistryAddress());
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        return new KafkaBrokerApi<>(containerState, kafkaPort, props);
+    }
+
+    public String getAddress() {
+        return containerState.getHost() + ":" + kafkaPort;
+    }
+
+    public AdminClient createAdminClient() {
+        final Properties props = new Properties();
+        props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, getAddress());
+        return AdminClient.create(props);
+    }
+}

--- a/src/test/java/io/debezium/connector/spanner/util/KafkaBrokerApi.java
+++ b/src/test/java/io/debezium/connector/spanner/util/KafkaBrokerApi.java
@@ -7,18 +7,13 @@ package io.debezium.connector.spanner.util;
 
 import java.util.Properties;
 
-import org.apache.avro.generic.GenericRecord;
 import org.apache.commons.lang3.SerializationUtils;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.connect.json.JsonDeserializer;
 import org.testcontainers.containers.ContainerState;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
-
-import io.confluent.kafka.serializers.KafkaAvroDeserializer;
-import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig;
 
 public class KafkaBrokerApi<K, V> {
 
@@ -48,25 +43,10 @@ public class KafkaBrokerApi<K, V> {
         return SCHEMA_REGISTRY_HOST + ":" + SCHEMA_REGISTRY_PORT;
     }
 
-    public static KafkaBrokerApi<GenericRecord, GenericRecord> createKafkaBrokerApiGenericRecord(
-                                                                                                 ContainerState containerState, int kafkaPort) {
-        final Properties props = new Properties();
-        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, containerState.getHost() + ":" + kafkaPort);
-        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, KafkaAvroDeserializer.class.getName());
-        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, KafkaAvroDeserializer.class.getName());
-        props.put(KafkaAvroDeserializerConfig.SCHEMA_REGISTRY_URL_CONFIG, getSchemaRegistryAddress());
-        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-        props.put(KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG, false);
-        return new KafkaBrokerApi<>(containerState, kafkaPort, props);
-    }
-
     public static KafkaBrokerApi<ObjectNode, ObjectNode> createKafkaBrokerApiObjectNode(ContainerState containerState,
                                                                                         int kafkaPort) {
         final Properties props = new Properties();
         props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, containerState.getHost() + ":" + kafkaPort);
-        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class.getName());
-        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class.getName());
-        props.put(KafkaAvroDeserializerConfig.SCHEMA_REGISTRY_URL_CONFIG, getSchemaRegistryAddress());
         props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
         return new KafkaBrokerApi<>(containerState, kafkaPort, props);
     }

--- a/src/test/java/io/debezium/connector/spanner/util/KafkaEnvironment.java
+++ b/src/test/java/io/debezium/connector/spanner/util/KafkaEnvironment.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.spanner.util;
+
+import java.io.File;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Set;
+
+import org.apache.avro.generic.GenericRecord;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.ListTopicsResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.ContainerState;
+import org.testcontainers.containers.DockerComposeContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+public class KafkaEnvironment {
+
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaEnvironment.class);
+
+    private static final String KAFKA_BROKER_SERVICE_NAME = "broker_1";
+    private static final int KAFKA_BROKER_SERVICE_API_PORT = 9092;
+
+    private static final String SCHEMA_REGISTRY_NAME = "schema-registry_1";
+    private static final int SCHEMA_REGISTRY_API_PORT = 8081;
+
+    public static final Duration STARTUP_TIMEOUT = Duration.ofSeconds(200L);
+    public static final Duration STARTUP_CONNECTOR_TIMEOUT = Duration.ofSeconds(600L);
+    public static final Duration CONFIGURE_CONNECTOR_TIMEOUT = Duration.ofSeconds(200L);
+
+    public static final String DOCKER_COMPOSE_FILE = "src/test/java/io/debezium/connector/spanner/util/docker-compose.yml";
+    public static final KafkaEnvironment TEST_KAFKA_ENVIRONMENT = new KafkaEnvironment(DOCKER_COMPOSE_FILE);
+
+    private boolean isStarted = false;
+
+    private DockerComposeContainer composeContainer;
+
+    private KafkaBrokerApi<ObjectNode, ObjectNode> brokerApiOn;
+
+    private KafkaBrokerApi<GenericRecord, GenericRecord> brokerApiGr;
+
+    public KafkaEnvironment(String dockerComposeFilePath) {
+        System.out.println("Initializing kafka environment for IT test...");
+        this.composeContainer = new DockerComposeContainer(new File(dockerComposeFilePath))
+                .withExposedService(KAFKA_BROKER_SERVICE_NAME, KAFKA_BROKER_SERVICE_API_PORT,
+                        Wait.forListeningPort().withStartupTimeout(STARTUP_TIMEOUT))
+                .withExposedService(SCHEMA_REGISTRY_NAME, SCHEMA_REGISTRY_API_PORT,
+                        Wait.forListeningPort().withStartupTimeout(STARTUP_TIMEOUT));
+        System.out.println("Finished initializing kafka environment.");
+    }
+
+    public void start() {
+
+        System.out.println("Starting Kafka environment");
+        this.composeContainer.start();
+        ContainerState brokerState = (ContainerState) composeContainer
+                .getContainerByServiceName(KAFKA_BROKER_SERVICE_NAME)
+                .orElseThrow();
+
+        this.brokerApiOn = KafkaBrokerApi.createKafkaBrokerApiObjectNode(brokerState, KAFKA_BROKER_SERVICE_API_PORT);
+        this.brokerApiGr = KafkaBrokerApi.createKafkaBrokerApiGenericRecord(brokerState, KAFKA_BROKER_SERVICE_API_PORT);
+    }
+
+    public KafkaBrokerApi<ObjectNode, ObjectNode> kafkaBrokerApiOn() {
+        return brokerApiOn;
+    }
+
+    public KafkaBrokerApi<GenericRecord, GenericRecord> kafkaBrokerApiGr() {
+        return brokerApiGr;
+    }
+
+    public boolean isStarted() {
+        return isStarted;
+    }
+
+    public void setStarted() {
+        isStarted = true;
+    }
+
+    public void clearTopics() {
+        try (AdminClient adminClient = kafkaBrokerApiOn().createAdminClient()) {
+            ListTopicsResult listTopicsResult = adminClient.listTopics();
+            Set<String> topics = listTopicsResult.names().get();
+            Arrays.asList("_kafka-connect-configs",
+                    "_kafka-connect-offsets",
+                    "_kafka-connect-status",
+                    "_kafka-connect-status",
+                    "_schemas",
+                    "_confluent-command",
+                    "_confluent_balancer_api_state",
+                    "_confluent-metrics",
+                    "__consumer_offsets",
+                    "_confluent-telemetry-metrics",
+                    "_rebalancing_topic_spanner_connector_testing-connector").forEach(
+                            topics::remove);
+            adminClient.deleteTopics(topics);
+        }
+        catch (Exception e) {
+            System.out.println(e.getMessage());
+        }
+    }
+}

--- a/src/test/java/io/debezium/connector/spanner/util/SchemaRegistryApi.java
+++ b/src/test/java/io/debezium/connector/spanner/util/SchemaRegistryApi.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.spanner.util;
+
+import org.testcontainers.containers.ContainerState;
+
+import okhttp3.MediaType;
+
+public class SchemaRegistryApi {
+
+    public static final MediaType JSON = MediaType.get("application/json; charset=utf-8");
+
+    private final ContainerState containerState;
+    private final int kafkaHttpPort;
+
+    public SchemaRegistryApi(ContainerState containerState, int schemaRegistryApiPort) {
+        this.containerState = containerState;
+        this.kafkaHttpPort = schemaRegistryApiPort;
+    }
+
+    private String getAddress() {
+        return containerState.getHost() + ":" + containerState.getMappedPort(kafkaHttpPort);
+    }
+
+    public String getSchemaRegistryEndpoint() {
+        return "http://" + getAddress();
+    }
+}

--- a/src/test/java/io/debezium/connector/spanner/util/docker-compose.yml
+++ b/src/test/java/io/debezium/connector/spanner/util/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2"
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.2.2
+    image: debezium/zookeeper:latest
     hostname: zookeeper
     ports:
       - "2181:2181"
@@ -10,7 +10,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-server:7.2.2
+    image: debezium/kafka:latest
     hostname: broker
     depends_on:
       - zookeeper
@@ -23,33 +23,15 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
       KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_LISTENERS: PLAINTEXT://:29092,PLAINTEXT_HOST://0.0.0.0:9092
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker:29092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_REST_HOST_NAME: 0.0.0.0
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
-      KAFKA_METRIC_REPORTERS: io.confluent.metrics.reporter.ConfluentMetricsReporter
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 100 # make kafka more responsible
-      KAFKA_CONFLUENT_LICENSE_TOPIC_REPLICATION_FACTOR: 1
-      KAFKA_CONFLUENT_BALANCER_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
       KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
       KAFKA_JMX_PORT: 9101
       KAFKA_JMX_HOSTNAME: localhost
-      KAFKA_CONFLUENT_SCHEMA_REGISTRY_URL: http://schema-registry:8081
-      CONFLUENT_METRICS_REPORTER_BOOTSTRAP_SERVERS: broker:29092
-      CONFLUENT_METRICS_REPORTER_TOPIC_REPLICAS: 1
-      CONFLUENT_METRICS_ENABLE: "true"
-      CONFLUENT_SUPPORT_CUSTOMER_ID: "anonymous"
+      ZOOKEEPER_CONNECT: zookeeper:2181
 
-  schema-registry:
-    image: confluentinc/cp-schema-registry:7.2.2
-    hostname: schema-registry
-    depends_on:
-      - broker
-      - zookeeper
-    ports:
-      - "8081:8081"
-    environment:
-      SCHEMA_REGISTRY_HOST_NAME: schema-registry
-      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: "broker:29092"
-      SCHEMA_REGISTRY_LISTENERS: http://0.0.0.0:8081
-      SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: zookeeper:2181

--- a/src/test/java/io/debezium/connector/spanner/util/docker-compose.yml
+++ b/src/test/java/io/debezium/connector/spanner/util/docker-compose.yml
@@ -1,0 +1,55 @@
+version: "2"
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.2.2
+    hostname: zookeeper
+    ports:
+      - "2181:2181"
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+
+  broker:
+    image: confluentinc/cp-server:7.2.2
+    hostname: broker
+    depends_on:
+      - zookeeper
+    ports:
+      # See https://rmoff.net/2018/08/02/kafka-listeners-explained/ for details
+      - "9092:9092"
+      - "9101:9101"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker:29092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
+      KAFKA_METRIC_REPORTERS: io.confluent.metrics.reporter.ConfluentMetricsReporter
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 100 # make kafka more responsible
+      KAFKA_CONFLUENT_LICENSE_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_CONFLUENT_BALANCER_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_JMX_PORT: 9101
+      KAFKA_JMX_HOSTNAME: localhost
+      KAFKA_CONFLUENT_SCHEMA_REGISTRY_URL: http://schema-registry:8081
+      CONFLUENT_METRICS_REPORTER_BOOTSTRAP_SERVERS: broker:29092
+      CONFLUENT_METRICS_REPORTER_TOPIC_REPLICAS: 1
+      CONFLUENT_METRICS_ENABLE: "true"
+      CONFLUENT_SUPPORT_CUSTOMER_ID: "anonymous"
+
+  schema-registry:
+    image: confluentinc/cp-schema-registry:7.2.2
+    hostname: schema-registry
+    depends_on:
+      - broker
+      - zookeeper
+    ports:
+      - "8081:8081"
+    environment:
+      SCHEMA_REGISTRY_HOST_NAME: schema-registry
+      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: "broker:29092"
+      SCHEMA_REGISTRY_LISTENERS: http://0.0.0.0:8081
+      SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: zookeeper:2181


### PR DESCRIPTION
Cloud Spanner emulator now supports change streams in googlesql dialect. This pr adds multiple basic ITs against a local running Cloud Spanner emulator instance. Currently the ITs will not pass in github CI/CD environment because we are pulling the Cloud Spanner emulator image from a private container registry. I will change to pull the emulator image from official public emulator registry once next release is rolled out. Draft this pr for now for easier early review. 