### PR TITLE
DBZ-6974 decrease time spent in rebalance event handling

### DIFF
--- a/src/main/java/io/debezium/connector/spanner/db/metadata/SchemaRegistry.java
+++ b/src/main/java/io/debezium/connector/spanner/db/metadata/SchemaRegistry.java
@@ -51,11 +51,13 @@ public class SchemaRegistry {
         this.schemaResetTrigger = schemaResetTrigger;
     }
 
-    public void init() {
+    public void init(String taskUid) {
         // Always initialize the schema registry to current time so the connector can start
         // successfully even when the gcp.spanner.start.time from configuration is out of
         // the maximum retention window.
-        forceUpdateSchema(null, Timestamp.now(), null);
+        LOGGER.info("Task Uid, initializing schema registry", taskUid);
+        forceUpdateSchema(taskUid, null, Timestamp.now(), null);
+        LOGGER.info("Task Uid, done initializing schema registry", taskUid);
     }
 
     public synchronized TableSchema getWatchedTable(TableId tableId) {
@@ -104,7 +106,7 @@ public class SchemaRegistry {
         }
 
         LOGGER.info("Schema is outdated. Try to update schema registry...");
-        forceUpdateSchema(tableId, updatedTimestamp, rowType);
+        forceUpdateSchema("", tableId, updatedTimestamp, rowType);
         LOGGER.info("Schema registry has been updated to date {}", updatedTimestamp);
         return true;
     }
@@ -132,8 +134,9 @@ public class SchemaRegistry {
     }
 
     @VisibleForTesting
-    void forceUpdateSchema(@Nullable TableId tableId, Timestamp updatedTimestamp, @Nullable List<Column> rowTypes) {
+    void forceUpdateSchema(String taskUid, @Nullable TableId tableId, Timestamp updatedTimestamp, @Nullable List<Column> rowTypes) {
         try {
+            LOGGER.info("Task {}, started updating schema registry", taskUid);
             this.timestamp = updatedTimestamp;
             this.changeStream = schemaDao.getStream(timestamp, streamName);
 
@@ -154,8 +157,10 @@ public class SchemaRegistry {
                 return;
             }
             this.spannerSchema = SchemaMerger.merge(this.spannerSchema, newSchema);
+            LOGGER.info("Task {} merged schema ", taskUid);
         }
         catch (SpannerException e) {
+            LOGGER.error("Task {} received exception {} when initializing schema registry", taskUid, e);
             // To prevent potential data loss when schema is updated but connector tries to query old schema out of the maximum retention window,
             // we first catch the spanner exception and verify the cause. If it indicates a exceed maximum timestamp staleness message with an
             // error code of FAILED_PRECONDITION, perform a manual update to merge the out of retention schema with current schema. Otherwise the
@@ -166,6 +171,10 @@ public class SchemaRegistry {
             else {
                 throw e;
             }
+        }
+        catch (Exception e) {
+            LOGGER.error("Task {} received exception {} when initializing schema registry", taskUid, e);
+            throw e;
         }
     }
 

--- a/src/main/java/io/debezium/connector/spanner/task/RebalanceHandler.java
+++ b/src/main/java/io/debezium/connector/spanner/task/RebalanceHandler.java
@@ -47,12 +47,13 @@ public class RebalanceHandler {
                 rebalanceGenerationId, isLeader);
 
         long oldRebalanceGenerationId = taskSyncContextHolder.get().getRebalanceGenerationId();
-        if (rebalanceGenerationId < oldRebalanceGenerationId) {
+        long lastReceivedRebalanceGenerationId = taskSyncContextHolder.get().getReceivedRebalanceGenerationId();
+        if (rebalanceGenerationId < oldRebalanceGenerationId || rebalanceGenerationId < lastReceivedRebalanceGenerationId) {
             LOGGER.info(
-                    "processRebalancingEvent: skipping due to stale rebalance generation ID {}, consumerId: {}, taskId{}, rebalanceGenerationId: {}, isLeader {}",
+                    "processRebalancingEvent: skipping due to stale rebalance generation ID {}, consumerId: {}, taskId{}, rebalanceGenerationId: {}, last received rebalance generation ID {}, isLeader {}",
                     rebalanceGenerationId, consumerId,
                     taskSyncContextHolder.get().getTaskUid(),
-                    rebalanceGenerationId, isLeader);
+                    rebalanceGenerationId, lastReceivedRebalanceGenerationId, isLeader);
             return;
         }
 

--- a/src/main/java/io/debezium/connector/spanner/task/SyncEventHandler.java
+++ b/src/main/java/io/debezium/connector/spanner/task/SyncEventHandler.java
@@ -160,8 +160,8 @@ public class SyncEventHandler {
 
     public void processRebalanceAnswer(TaskSyncEvent inSync, SyncEventMetadata metadata) {
 
-        LOGGER.debug("Task {} - process sync event - rebalance answer",
-                taskSyncContextHolder.get().getTaskUid());
+        LOGGER.info("Task {} - process sync event - rebalance answer from task {} with generation {}",
+                taskSyncContextHolder.get().getTaskUid(), inSync.getTaskUid(), inSync.getRebalanceGenerationId());
 
         taskSyncContextHolder.update(context -> SyncEventMerger.mergeRebalanceAnswer(context, inSync));
 

--- a/src/main/java/io/debezium/connector/spanner/task/SyncEventMerger.java
+++ b/src/main/java/io/debezium/connector/spanner/task/SyncEventMerger.java
@@ -93,7 +93,7 @@ public class SyncEventMerger {
 
         TaskState newTask = newMessage.getTaskStates().get(newMessage.getTaskUid());
         if (newTask == null) {
-            LOGGER.warn("The rebalance answer {} did not contain the task's UID: {}", newMessage, newMessage.getTaskUid());
+            LOGGER.warn("Task {}, The rebalance answer {} did not contain the task's UID: {}", currentContext.getTaskUid(), newMessage, newMessage.getTaskUid());
             return builder.build();
         }
 
@@ -123,6 +123,12 @@ public class SyncEventMerger {
                     result.getNumPartitions(), result.getNumSharedPartitions(), oldPartitions);
 
             return result;
+        }
+        else {
+            LOGGER.info(
+                    "Task {}, Skipping rebalance answer from task {} for rebalance generation id {}",
+                    currentContext.getTaskUid(), newMessage.getTaskUid(),
+                    newMessage.getRebalanceGenerationId());
         }
         LOGGER.debug("merge: final state is not changed");
 

--- a/src/main/java/io/debezium/connector/spanner/task/SyncEventMerger.java
+++ b/src/main/java/io/debezium/connector/spanner/task/SyncEventMerger.java
@@ -91,10 +91,6 @@ public class SyncEventMerger {
 
         var builder = currentContext.toBuilder();
 
-        if (!currentContext.isLeader() || !currentContext.getRebalanceState().equals(RebalanceState.INITIAL_INCREMENTED_STATE_COMPLETED)) {
-            return builder.build();
-        }
-
         TaskState newTask = newMessage.getTaskStates().get(newMessage.getTaskUid());
         if (newTask == null) {
             LOGGER.warn("The rebalance answer {} did not contain the task's UID: {}", newMessage, newMessage.getTaskUid());

--- a/src/main/java/io/debezium/connector/spanner/task/SynchronizationTaskContext.java
+++ b/src/main/java/io/debezium/connector/spanner/task/SynchronizationTaskContext.java
@@ -190,7 +190,13 @@ public class SynchronizationTaskContext {
             this.lowWatermarkCalculationJob.start();
 
             LOGGER.info("{}, Init Schema Registry", task.getTaskUid());
-            this.schemaRegistry.init();
+            try {
+                this.schemaRegistry.init(this.task.getTaskUid());
+            }
+            catch (Exception e) {
+                LOGGER.error("{}, Init Schema Registry failure", task.getTaskUid());
+                throw e;
+            }
 
             LOGGER.info("{}, Start Processing Task State Change Event Processor", task.getTaskUid());
             this.taskStateChangeEventProcessor.startProcessing();
@@ -201,7 +207,12 @@ public class SynchronizationTaskContext {
             LOGGER.info("{}, Finished updating TaskSyncContextHolder", task.getTaskUid());
 
         }
-        catch (Throwable ex) {
+        catch (InterruptedException ex) {
+            LOGGER.error("Interrupted exception during SynchronizationTaskContext starting", ex);
+            this.onError(ex);
+
+        }
+        catch (Exception ex) {
             LOGGER.error("Exception during SynchronizationTaskContext starting", ex);
             this.onError(ex);
         }

--- a/src/test/java/io/debezium/connector/spanner/db/metadata/SchemaRegistryTest.java
+++ b/src/test/java/io/debezium/connector/spanner/db/metadata/SchemaRegistryTest.java
@@ -52,7 +52,7 @@ class SchemaRegistryTest {
         when(databaseClient.readOnlyTransaction(any())).thenReturn(readOnlyTransaction);
 
         SchemaRegistry schemaRegistry = new SchemaRegistry("Stream Name", new SchemaDao(databaseClient), mock(Runnable.class));
-        schemaRegistry.init();
+        schemaRegistry.init("taskUid");
 
         verify(databaseClient, atLeast(1)).readOnlyTransaction(any());
         verify(readOnlyTransaction, atLeast(1)).executeQuery(any(), any());


### PR DESCRIPTION
Previously, only leaders of the current rebalance generation can receive rebalance answers. This sometimes cause situations where the task became leader too late, and thus never received some of the rebalance answers. This would cause the current loop to fail, and a new generation of rebalancing to be started.

