### PR TITLE
DBZ-7348 Add support for new row old values value capture type.

### DIFF
--- a/src/main/java/io/debezium/connector/spanner/db/model/ValueCaptureType.java
+++ b/src/main/java/io/debezium/connector/spanner/db/model/ValueCaptureType.java
@@ -13,5 +13,6 @@ public enum ValueCaptureType {
     OLD_AND_NEW_VALUES,
     NEW_ROW,
     NEW_VALUES,
+    NEW_ROW_AND_OLD_VALUES,
     UNKNOWN
 }

--- a/src/test/java/io/debezium/connector/spanner/context/source/SourceInfoFactoryTest.java
+++ b/src/test/java/io/debezium/connector/spanner/context/source/SourceInfoFactoryTest.java
@@ -86,6 +86,59 @@ class SourceInfoFactoryTest {
     }
 
     @Test
+    void testGetSourceInfoNewRowAndOldValues() throws InterruptedException {
+        Configuration configuration = mock(Configuration.class);
+        when(configuration.getString((Field) any())).thenReturn("String");
+        when(configuration.asProperties()).thenReturn(new Properties());
+        when(configuration.getString(anyString())).thenReturn("String");
+        SpannerConnectorConfig connectorConfig = new SpannerConnectorConfig(configuration);
+        SourceInfoFactory sourceInfoFactory = new SourceInfoFactory(
+                connectorConfig, mock(LowWatermarkProvider.class));
+        StreamEventMetadata streamEventMetadata = mock(StreamEventMetadata.class);
+        when(streamEventMetadata.getRecordReadAt()).thenReturn(Timestamp.ofTimeMicroseconds(1L));
+        ArrayList<Column> rowType = new ArrayList<>();
+
+        Timestamp commitTimestamp = Timestamp.ofTimeMicroseconds(1L);
+        Instant recordTimestamp = commitTimestamp.toSqlTimestamp().toInstant();
+        Instant readAtTimestamp = commitTimestamp.toSqlTimestamp().toInstant();
+        String serverTransactionId = "testId";
+        Long recordSequence = 1L;
+        Instant lowWatermark = null;
+        Long numberRecordsInTransaction = 1L;
+
+        DataChangeEvent dataChangeEvent = new DataChangeEvent("token", commitTimestamp,
+                "testId", true,
+                "1", "Table Name", rowType, new ArrayList<>(), ModType.INSERT,
+                ValueCaptureType.NEW_ROW_AND_OLD_VALUES, 1L, 1L,
+                "testTag=test", false, streamEventMetadata);
+
+        SourceInfo expected = new SourceInfo(connectorConfig, dataChangeEvent.getTableName(), recordTimestamp,
+                commitTimestamp.toSqlTimestamp().toInstant(), readAtTimestamp, serverTransactionId,
+                recordSequence,
+                lowWatermark, numberRecordsInTransaction, "testTag=test", false,
+                ValueCaptureType.NEW_ROW_AND_OLD_VALUES.name(), "testToken", 0, false, 1L);
+
+        SourceInfo sourceInfo = sourceInfoFactory.getSourceInfo(0,
+                new DataChangeEvent("token", commitTimestamp, "testId",
+                        true, "1", "Table Name", rowType,
+                        new ArrayList<>(), ModType.INSERT, ValueCaptureType.OLD_AND_NEW_VALUES, 1L,
+                        1L, "testTag=test", false, streamEventMetadata));
+
+        assertEquals(expected.getProjectId(), sourceInfo.getProjectId());
+        assertEquals(expected.getInstanceId(), sourceInfo.getInstanceId());
+        assertEquals(expected.getDatabaseId(), sourceInfo.getDatabaseId());
+        assertEquals(expected.getChangeStreamName(), sourceInfo.getChangeStreamName());
+        assertEquals(expected.getTableName(), sourceInfo.getTableName());
+        assertEquals(expected.getRecordTimestamp(), sourceInfo.getRecordTimestamp());
+        assertEquals(expected.getCommitTimestamp(), sourceInfo.getCommitTimestamp());
+        assertEquals(expected.getServerTransactionId(), sourceInfo.getServerTransactionId());
+        assertEquals(expected.getRecordSequence(), sourceInfo.getRecordSequence());
+        assertEquals(expected.getLowWatermark(), sourceInfo.getLowWatermark());
+        assertEquals(expected.getReadAtTimestamp(), sourceInfo.getReadAtTimestamp());
+        assertEquals(expected.getNumberRecordsInTransaction(), sourceInfo.getNumberRecordsInTransaction());
+    }
+
+    @Test
     void testGetSourceInfoNewRow() throws InterruptedException {
         Configuration configuration = mock(Configuration.class);
         when(configuration.getString((Field) any())).thenReturn("String");
@@ -121,6 +174,60 @@ class SourceInfoFactoryTest {
                 new DataChangeEvent("token", commitTimestamp, "testId",
                         true, "1", "Table Name", rowType,
                         new ArrayList<>(), ModType.INSERT, ValueCaptureType.NEW_ROW, 1L,
+                        1L, "testTag=test", false, streamEventMetadata));
+
+        assertEquals(expected.getValueCaptureType(), sourceInfo.getValueCaptureType());
+        assertEquals(expected.getProjectId(), sourceInfo.getProjectId());
+        assertEquals(expected.getInstanceId(), sourceInfo.getInstanceId());
+        assertEquals(expected.getDatabaseId(), sourceInfo.getDatabaseId());
+        assertEquals(expected.getChangeStreamName(), sourceInfo.getChangeStreamName());
+        assertEquals(expected.getTableName(), sourceInfo.getTableName());
+        assertEquals(expected.getRecordTimestamp(), sourceInfo.getRecordTimestamp());
+        assertEquals(expected.getCommitTimestamp(), sourceInfo.getCommitTimestamp());
+        assertEquals(expected.getServerTransactionId(), sourceInfo.getServerTransactionId());
+        assertEquals(expected.getRecordSequence(), sourceInfo.getRecordSequence());
+        assertEquals(expected.getLowWatermark(), sourceInfo.getLowWatermark());
+        assertEquals(expected.getReadAtTimestamp(), sourceInfo.getReadAtTimestamp());
+        assertEquals(expected.getNumberRecordsInTransaction(), sourceInfo.getNumberRecordsInTransaction());
+    }
+
+    @Test
+    void testGetSourceInfoNewValues() throws InterruptedException {
+        Configuration configuration = mock(Configuration.class);
+        when(configuration.getString((Field) any())).thenReturn("String");
+        when(configuration.asProperties()).thenReturn(new Properties());
+        when(configuration.getString(anyString())).thenReturn("String");
+        SpannerConnectorConfig connectorConfig = new SpannerConnectorConfig(configuration);
+        SourceInfoFactory sourceInfoFactory = new SourceInfoFactory(
+                connectorConfig, mock(LowWatermarkProvider.class));
+        StreamEventMetadata streamEventMetadata = mock(StreamEventMetadata.class);
+        when(streamEventMetadata.getRecordReadAt()).thenReturn(Timestamp.ofTimeMicroseconds(1L));
+        ArrayList<Column> rowType = new ArrayList<>();
+
+        Timestamp commitTimestamp = Timestamp.ofTimeMicroseconds(1L);
+        Instant recordTimestamp = commitTimestamp.toSqlTimestamp().toInstant();
+        Instant readAtTimestamp = commitTimestamp.toSqlTimestamp().toInstant();
+        String serverTransactionId = "testId";
+        Long recordSequence = 1L;
+        Instant lowWatermark = null;
+        Long numberRecordsInTransaction = 1L;
+
+        DataChangeEvent dataChangeEvent = new DataChangeEvent("token", commitTimestamp,
+                "testId", true,
+                "1", "Table Name", rowType, new ArrayList<>(), ModType.INSERT,
+                ValueCaptureType.NEW_VALUES, 1L, 1L,
+                "testTag=test", false, streamEventMetadata);
+
+        SourceInfo expected = new SourceInfo(connectorConfig, dataChangeEvent.getTableName(), recordTimestamp,
+                commitTimestamp.toSqlTimestamp().toInstant(), readAtTimestamp, serverTransactionId,
+                recordSequence,
+                lowWatermark, numberRecordsInTransaction, "testTag=test", false,
+                ValueCaptureType.NEW_VALUES.name(), "testToken", 0, false, 1L);
+
+        SourceInfo sourceInfo = sourceInfoFactory.getSourceInfo(0,
+                new DataChangeEvent("token", commitTimestamp, "testId",
+                        true, "1", "Table Name", rowType,
+                        new ArrayList<>(), ModType.INSERT, ValueCaptureType.NEW_VALUES, 1L,
                         1L, "testTag=test", false, streamEventMetadata));
 
         assertEquals(expected.getValueCaptureType(), sourceInfo.getValueCaptureType());

--- a/src/test/java/io/debezium/connector/spanner/db/mapper/ChangeStreamRecordMapperTest.java
+++ b/src/test/java/io/debezium/connector/spanner/db/mapper/ChangeStreamRecordMapperTest.java
@@ -270,6 +270,131 @@ class ChangeStreamRecordMapperTest {
                 changeStreamRecordMapper.toChangeStreamEvents(partition, resultSet, resultSetMetadata));
     }
 
+    /*
+     * Change streams with NEW_ROW_AND_OLD_VALUES value capture type do not track
+     * non-changed old values.
+     */
+    @Test
+    public void testMappingUpdateJsonRowNewRowAndOldValuesToDataChangeRecord() {
+        final DataChangeEvent dataChangeRecord = new DataChangeEvent(
+                "partitionToken",
+                Timestamp.ofTimeSecondsAndNanos(10L, 20),
+                "serverTransactionId",
+                true,
+                "1",
+                "tableName",
+                Arrays.asList(
+                        new Column("column1", ColumnTypeParser.parse("{\"code\":\"INT64\"}"), true,
+                                1L, false),
+                        new Column("column2", ColumnTypeParser.parse("{\"code\":\"BYTES\"}"), false,
+                                2L, true),
+                        new Column("column3", ColumnTypeParser.parse("{\"code\":\"STRING\"}"),
+                                false,
+                                3L, true)),
+                Collections.singletonList(
+                        new Mod(1, MapperUtils.getJsonNode("{\"column1\":\"value1\"}"),
+                                MapperUtils.getJsonNode("{\"column3\":\"oldValue3\"}"),
+                                MapperUtils.getJsonNode(
+                                        "{\"column2\":\"newValue2\",\"column3\":\"newValue3\"}"))),
+                ModType.UPDATE,
+                ValueCaptureType.NEW_ROW_AND_OLD_VALUES,
+                10L,
+                2L,
+                "transactionTag",
+                true,
+                changeStreamRecordMapper.streamEventMetadataFrom(partition,
+                        Timestamp.ofTimeSecondsAndNanos(10L, 20), resultSetMetadata));
+        final String jsonString = TestJsonMapper.recordToJson(dataChangeRecord, false, false);
+
+        assertNotNull(jsonString);
+        ChangeStreamResultSet resultSet = mock(ChangeStreamResultSet.class);
+        when(resultSet.getPgJsonb(0)).thenReturn(jsonString);
+        assertEquals(
+                Collections.singletonList(dataChangeRecord),
+                changeStreamRecordMapper.toChangeStreamEvents(partition, resultSet, resultSetMetadata));
+    }
+
+    @Test
+    public void testMappingInsertJsonRowNewRowAndOldValuesToDataChangeRecord() {
+        final DataChangeEvent dataChangeRecord = new DataChangeEvent(
+                "partitionToken",
+                Timestamp.ofTimeSecondsAndNanos(10L, 20),
+                "serverTransactionId",
+                true,
+                "1",
+                "tableName",
+                Arrays.asList(
+                        new Column("column1", ColumnTypeParser.parse("{\"code\":\"INT64\"}"), true,
+                                1L, false),
+                        new Column("column2", ColumnTypeParser.parse("{\"code\":\"BYTES\"}"), false,
+                                2L, true),
+                        new Column("column3", ColumnTypeParser.parse("{\"code\":\"STRING\"}"),
+                                false,
+                                3L, true)),
+                Collections.singletonList(
+                        new Mod(1, MapperUtils.getJsonNode("{\"column1\":\"value1\"}"),
+                                MapperUtils.getJsonNode("{}"),
+                                MapperUtils.getJsonNode(
+                                        "{\"column2\":\"newValue2\",\"column3\":\"newValue3\"}"))),
+                ModType.INSERT,
+                ValueCaptureType.NEW_ROW_AND_OLD_VALUES,
+                10L,
+                2L,
+                "transactionTag",
+                true,
+                changeStreamRecordMapper.streamEventMetadataFrom(partition,
+                        Timestamp.ofTimeSecondsAndNanos(10L, 20), resultSetMetadata));
+        final String jsonString = TestJsonMapper.recordToJson(dataChangeRecord, false, false);
+
+        assertNotNull(jsonString);
+        ChangeStreamResultSet resultSet = mock(ChangeStreamResultSet.class);
+        when(resultSet.getPgJsonb(0)).thenReturn(jsonString);
+        assertEquals(
+                Collections.singletonList(dataChangeRecord),
+                changeStreamRecordMapper.toChangeStreamEvents(partition, resultSet, resultSetMetadata));
+    }
+
+    @Test
+    public void testMappingDeletesonRowNewRowAndOldValuesToDataChangeRecord() {
+        final DataChangeEvent dataChangeRecord = new DataChangeEvent(
+                "partitionToken",
+                Timestamp.ofTimeSecondsAndNanos(10L, 20),
+                "serverTransactionId",
+                true,
+                "1",
+                "tableName",
+                Arrays.asList(
+                        new Column("column1", ColumnTypeParser.parse("{\"code\":\"INT64\"}"), true,
+                                1L, false),
+                        new Column("column2", ColumnTypeParser.parse("{\"code\":\"BYTES\"}"), false,
+                                2L, true),
+                        new Column("column3", ColumnTypeParser.parse("{\"code\":\"STRING\"}"),
+                                false,
+                                3L, true)),
+                Collections.singletonList(
+                        new Mod(1, MapperUtils.getJsonNode("{\"column1\":\"value1\"}"),
+                                MapperUtils.getJsonNode(
+                                        "{\"column2\":\"newValue2\",\"column3\":\"newValue3\"}"),
+                                MapperUtils.getJsonNode(
+                                        "{}"))),
+                ModType.DELETE,
+                ValueCaptureType.NEW_ROW_AND_OLD_VALUES,
+                10L,
+                2L,
+                "transactionTag",
+                true,
+                changeStreamRecordMapper.streamEventMetadataFrom(partition,
+                        Timestamp.ofTimeSecondsAndNanos(10L, 20), resultSetMetadata));
+        final String jsonString = TestJsonMapper.recordToJson(dataChangeRecord, false, false);
+
+        assertNotNull(jsonString);
+        ChangeStreamResultSet resultSet = mock(ChangeStreamResultSet.class);
+        when(resultSet.getPgJsonb(0)).thenReturn(jsonString);
+        assertEquals(
+                Collections.singletonList(dataChangeRecord),
+                changeStreamRecordMapper.toChangeStreamEvents(partition, resultSet, resultSetMetadata));
+    }
+
     @Test
     public void testMappingJsonRowWithUnknownModTypeAndValueCaptureTypeToDataChangeRecord() {
         final DataChangeEvent dataChangeRecord = new DataChangeEvent(


### PR DESCRIPTION
Add a new value capture type enum value for `NEW_ROW_AND_OLD_VALUES`.