### PR TITLE
DBZ-6998: Align min, max of Histogram/Statistics

### DIFF
--- a/src/main/java/io/debezium/connector/spanner/metrics/latency/Statistics.java
+++ b/src/main/java/io/debezium/connector/spanner/metrics/latency/Statistics.java
@@ -44,8 +44,8 @@ public class Statistics {
         quantileMeter.shutdown();
     }
 
-    public synchronized void update(long value) {
-
+    void set(Duration lastDuration) {
+        long value = lastDuration.toMillis();
         if (minValue.get() > value) {
             minValue.set(value);
         }
@@ -61,6 +61,10 @@ public class Statistics {
         lastValue.set(value);
 
         quantileMeter.addValue((double) value);
+    }
+
+    public synchronized void update(long value) {
+        set(Duration.ofMillis(value));
     }
 
     public Long getMinValue() {


### PR DESCRIPTION
Motivation:
Users experienced inconvenience because the statistics-related class was implemented separately. So that we abstracted common methods.

Modification:
- Fix(Statistics): Add set method

Result:
User experience will be improved by common methods.