### PR TITLE
DBZ-8043 Support FLOAT32 type

### DIFF
--- a/src/main/java/io/debezium/connector/spanner/db/model/schema/Column.java
+++ b/src/main/java/io/debezium/connector/spanner/db/model/schema/Column.java
@@ -63,6 +63,9 @@ public class Column {
                 if ("INT64".equals(spannerType)) {
                     return new ColumnType(DataType.INT64);
                 }
+                if ("FLOAT32".equals(spannerType)) {
+                    return new ColumnType(DataType.FLOAT32);
+                }
                 if ("FLOAT64".equals(spannerType)) {
                     return new ColumnType(DataType.FLOAT64);
                 }
@@ -104,6 +107,9 @@ public class Column {
                 }
                 if ("BIGINT".equals(spannerType)) {
                     return new ColumnType(DataType.INT64);
+                }
+                if ("REAL".equals(spannerType)) {
+                    return new ColumnType(DataType.FLOAT32);
                 }
                 if ("DOUBLE PRECISION".equals(spannerType)) {
                     return new ColumnType(DataType.FLOAT64);

--- a/src/main/java/io/debezium/connector/spanner/db/model/schema/DataType.java
+++ b/src/main/java/io/debezium/connector/spanner/db/model/schema/DataType.java
@@ -11,6 +11,7 @@ package io.debezium.connector.spanner.db.model.schema;
 public enum DataType {
     BOOL,
     INT64,
+    FLOAT32,
     FLOAT64,
     TIMESTAMP,
     DATE,

--- a/src/main/java/io/debezium/connector/spanner/schema/mapper/ColumnTypeSchemaMapper.java
+++ b/src/main/java/io/debezium/connector/spanner/schema/mapper/ColumnTypeSchemaMapper.java
@@ -30,6 +30,8 @@ public class ColumnTypeSchemaMapper {
                 return optional ? Schema.OPTIONAL_INT64_SCHEMA : Schema.INT64_SCHEMA;
             case BOOL:
                 return optional ? Schema.OPTIONAL_BOOLEAN_SCHEMA : Schema.BOOLEAN_SCHEMA;
+            case FLOAT32:
+                return optional ? Schema.OPTIONAL_FLOAT32_SCHEMA : Schema.FLOAT32_SCHEMA;
             case FLOAT64:
                 return optional ? Schema.OPTIONAL_FLOAT64_SCHEMA : Schema.FLOAT64_SCHEMA;
             case ARRAY:
@@ -60,6 +62,8 @@ public class ColumnTypeSchemaMapper {
                 return optional ? Schema.OPTIONAL_INT64_SCHEMA : Schema.INT64_SCHEMA;
             case BOOL:
                 return optional ? Schema.OPTIONAL_BOOLEAN_SCHEMA : Schema.BOOLEAN_SCHEMA;
+            case FLOAT32:
+                return optional ? Schema.OPTIONAL_FLOAT32_SCHEMA : Schema.FLOAT32_SCHEMA;
             case FLOAT64:
                 return optional ? Schema.OPTIONAL_FLOAT64_SCHEMA : Schema.FLOAT64_SCHEMA;
             case BYTES:

--- a/src/test/java/io/debezium/connector/spanner/kafka/schema/mapper/ColumnTypeSchemaMapperTest.java
+++ b/src/test/java/io/debezium/connector/spanner/kafka/schema/mapper/ColumnTypeSchemaMapperTest.java
@@ -51,6 +51,10 @@ class ColumnTypeSchemaMapperTest {
                         Schema.OPTIONAL_BOOLEAN_SCHEMA),
 
                 Arguments.of(
+                        ColumnTypeSchemaMapper.getSchema(ColumnTypeParser.parse("{\"code\":\"FLOAT32\"}"), true),
+                        Schema.OPTIONAL_FLOAT32_SCHEMA),
+
+                Arguments.of(
                         ColumnTypeSchemaMapper.getSchema(ColumnTypeParser.parse("{\"code\":\"FLOAT64\"}"), true),
                         Schema.OPTIONAL_FLOAT64_SCHEMA),
 


### PR DESCRIPTION
Spanner now supports the FLOAT32 type. This change creates a mapping between "FLOAT32" / "REAL" to Kafka's FLOAT32_SCHEMA