### PR TITLE
DBZ-8046 Add workflow to manually deploy connector to docker hub for local testing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -506,6 +506,9 @@
                         <configuration>
                             <repository>${docker.repository.name}</repository>
                             <skip>${docker.skip.push}</skip>
+                            <buildArgs>
+                                <projectVersion>${project.version}</projectVersion>
+                            </buildArgs>
                             <images>
                                 <image>
                                     <name>${docker.repository.name}:${docker.tag.name}</name>
@@ -616,6 +619,37 @@
                                     <descriptorRefs>
                                         <descriptorRef>${assembly.descriptor}</descriptorRef>
                                     </descriptorRefs>
+                                    <tarLongFileMode>posix</tarLongFileMode>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>pack-local-changes</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <version>${version.assembly.plugin}</version>
+                        <executions>
+                            <execution>
+                                <id>pack-local-changes</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>single</goal>
+                                </goals>
+                                <configuration>
+                                    <finalName>${project.artifactId}-${project.version}</finalName>
+                                    <descriptors>
+                                        <descriptor>src/test/docker/distribution.xml</descriptor>
+                                    </descriptors>
                                     <tarLongFileMode>posix</tarLongFileMode>
                                 </configuration>
                             </execution>

--- a/src/test/docker/Dockerfile
+++ b/src/test/docker/Dockerfile
@@ -1,7 +1,9 @@
-FROM confluentinc/cp-kafka-connect-base:7.2.2
-COPY target/components/packages/google-debezium-connector-spanner-*.zip /usr/share/confluent-hub-components/google-debezium-connector-spanner.zip
+FROM confluentinc/cp-kafka-connect-base:latest
+ARG projectVersion
+USER root
+RUN yum remove -y zulu11-ca-jdk-headless && yum remove -y zulu11-ca-jre-headless
+RUN yum install -y zulu17-ca-jdk-headless && yum install -y zulu17-ca-jre-headless
+USER appuser
+COPY target/debezium-connector-spanner-${projectVersion}-plugin/ /usr/share/java/google-debezium-connector-spanner/
 COPY src/test/docker/jmx_prometheus_javaagent-0.16.1.jar /usr/share/prometheus/jmx_prometheus_javaagent.jar
 COPY src/test/docker/metrics-config.yml /usr/share/prometheus/metrics-config.yml
-RUN confluent-hub install --no-prompt wepay/kafka-connect-bigquery:latest
-RUN confluent-hub install --no-prompt /usr/share/confluent-hub-components/google-debezium-connector-spanner.zip
-#CMD ["/bin/bash", "-c", "/etc/confluent/docker/run &; sleep infinity"]

--- a/src/test/docker/distribution.xml
+++ b/src/test/docker/distribution.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0"?>
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+  <id>plugin</id>
+  <formats>
+    <format>dir</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <dependencySets>
+    <dependencySet>
+      <outputDirectory>${project.artifactId}</outputDirectory>
+      <unpack>false</unpack>
+      <scope>runtime</scope>
+      <useProjectArtifact>false</useProjectArtifact>
+      <useTransitiveFiltering>true</useTransitiveFiltering>
+      <excludes>
+        <!-- Exclude dependencies of Kafka APIs, since they will be available in the runtime -->
+        <exclude>com.fasterxml.jackson.core:jackson-core:*</exclude>
+        <exclude>com.fasterxml.jackson.core:jackson-databind:*</exclude>
+        <exclude>com.fasterxml.jackson.core:jackson-annotations:*</exclude>
+        <exclude>com.fasterxml.jackson.datatype:jackson-datatype-jsr310:*</exclude>
+
+        <!-- Exclude guava dependencies -->
+        <exclude>com.google.guava:listenablefuture:*</exclude>
+
+        <!-- Exclude dependencies with incorrect scope -->
+        <exclude>org.checkerframework:checker-qual:*</exclude>
+      </excludes>
+    </dependencySet>
+    <dependencySet>
+      <outputDirectory>${project.artifactId}</outputDirectory>
+      <unpack>false</unpack>
+      <includes>
+        <include>${project.groupId}:${project.artifactId}:*</include>
+      </includes>
+    </dependencySet>
+  </dependencySets>
+  <fileSets>
+    <fileSet>
+      <directory>${project.basedir}</directory>
+      <outputDirectory>${project.artifactId}</outputDirectory>
+      <includes>
+        <include>README*</include>
+        <include>LICENSE*</include>
+      </includes>
+      <useDefaultExcludes>true</useDefaultExcludes>
+    </fileSet>
+    <fileSet>
+      <directory>${project.build.directory}/generated-sources</directory>
+      <outputDirectory>${project.artifactId}</outputDirectory>
+      <includes>
+        <include>*.json</include>
+      </includes>
+      <useDefaultExcludes>true</useDefaultExcludes>
+    </fileSet>
+  </fileSets>
+</assembly>


### PR DESCRIPTION
This pull request resolves the incompatibility of the Kafka Connect Maven plugin with Debezium 3, which previously prevented us from manually deploying the connector for testing.

Key Changes:

- New Profile (pack-lock-changes): This profile uses the maven-assembly-plugin to generate a directory containing all the runtime JAR files needed for running the connector. This directory can be directly installed on a Kafka Connect base image through dockerfile.

- Testing dockerfile updates: JDK 11 was uninstalled and replaced with JDK 17 due to the limitation of the confluentinc/cp-kafka-connect-base:latest image. This is necessary because our connector jar can't be executed with Java 11. Also removed the usage of confluent-hub install and directly install the connector plugin with COPY.

Long-Term Recommendation:

- To avoid future compatibility issues, we should update our testing infrastructure to use Debezium-based ecosystem. This will ensure smoother integration with future releases.