### PR TITLE
DBZ-8043 Fix FLOAT32 value conversions.

### DIFF
--- a/src/main/java/io/debezium/connector/spanner/schema/mapper/FieldJsonNodeValueMapper.java
+++ b/src/main/java/io/debezium/connector/spanner/schema/mapper/FieldJsonNodeValueMapper.java
@@ -21,6 +21,8 @@ public class FieldJsonNodeValueMapper {
     public static Object getValue(Field field, JsonNode node) {
         Schema.Type type = field.schema().type();
         switch (type) {
+            case FLOAT32:
+                return JsonNodeStructValueConvertor.getFloat(node);
             case FLOAT64:
                 return JsonNodeStructValueConvertor.getDouble(node);
             case STRING:

--- a/src/main/java/io/debezium/connector/spanner/schema/mapper/JsonNodeStructValueConvertor.java
+++ b/src/main/java/io/debezium/connector/spanner/schema/mapper/JsonNodeStructValueConvertor.java
@@ -39,6 +39,15 @@ public class JsonNodeStructValueConvertor {
         return node.asLong();
     }
 
+    public static Float getFloat(JsonNode node) {
+        if (node.isNull()) {
+            return null;
+        }
+        // It is safe to down cast here. Spanner has up casted the float32
+        // values to float64 while sending the response.
+        return (float) node.asDouble();
+    }
+
     public static Double getDouble(JsonNode node) {
         if (node.isNull()) {
             return null;
@@ -76,6 +85,8 @@ public class JsonNodeStructValueConvertor {
 
     private static Object getValueFromNode(JsonNode node, Schema.Type type) {
         switch (type) {
+            case FLOAT32:
+                return getFloat(node);
             case FLOAT64:
                 return getDouble(node);
             case STRING:

--- a/src/test/java/io/debezium/connector/spanner/AbstractSpannerConnectorIT.java
+++ b/src/test/java/io/debezium/connector/spanner/AbstractSpannerConnectorIT.java
@@ -21,6 +21,8 @@ public class AbstractSpannerConnectorIT extends AbstractConnectorTest {
             KafkaEnvironment.DOCKER_COMPOSE_FILE);
     protected static final Database database = Database.TEST_DATABASE;
     protected static final Connection databaseConnection = database.getConnection();
+    protected static final Database pgDatabase = Database.TEST_PG_DATABASE;
+    protected static final Connection pgDatabaseConnection = pgDatabase.getConnection();
     private static final String TEST_PROPERTY_PREFIX = "debezium.test.";
 
     static {
@@ -43,6 +45,12 @@ public class AbstractSpannerConnectorIT extends AbstractConnectorTest {
             .with("bootstrap.servers", KAFKA_ENVIRONMENT.kafkaBrokerApiOn().getAddress())
             .with("heartbeat.interval.ms", "300000")
             .with("gcp.spanner.low-watermark.enabled", false)
+            .build();
+
+    protected static final Configuration basePgConfig = Configuration.copy(baseConfig)
+            .with("gcp.spanner.instance.id", pgDatabase.getInstanceId())
+            .with("gcp.spanner.project.id", pgDatabase.getProjectId())
+            .with("gcp.spanner.database.id", pgDatabase.getDatabaseId())
             .build();
 
     @BeforeAll

--- a/src/test/java/io/debezium/connector/spanner/DataTypesIT.java
+++ b/src/test/java/io/debezium/connector/spanner/DataTypesIT.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.spanner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.config.Configuration;
+
+public class DataTypesIT extends AbstractSpannerConnectorIT {
+
+    private static final String tableName = "embedded_data_types_tests_table";
+    private static final String changeStreamName = "embeddedDataTypesTestChangeStream";
+    private static final List<String> types = Arrays.asList("BOOL", "INT64",
+            "FLOAT32", "FLOAT64", "TIMESTAMP", "DATE", "STRING", "BYTES",
+            "NUMERIC", "JSON");
+
+    @BeforeAll
+    static void setup() throws InterruptedException, ExecutionException {
+
+        databaseConnection.createTable(tableName + "(id INT64,"
+                + "  boolCol BOOL,"
+                + "  int64Col INT64,"
+                + "  float32Col FLOAT32,"
+                + "  float64Col FLOAT64,"
+                + "  timestampCol TIMESTAMP,"
+                + "  dateCol DATE,"
+                + "  stringCol STRING(MAX),"
+                + "  bytesCol BYTES(MAX),"
+                + "  numericCol NUMERIC,"
+                + "  jsonCol JSON,"
+                + "  arrCol ARRAY<STRING(MAX)>,"
+                + ") PRIMARY KEY (id)");
+        databaseConnection.createChangeStream(changeStreamName, tableName);
+
+        System.out.println("DataTypesIT is ready...");
+    }
+
+    @AfterAll
+    static void clear() throws InterruptedException {
+        databaseConnection.dropChangeStream(changeStreamName);
+        databaseConnection.dropTable(tableName);
+    }
+
+    @Test
+    public void shouldStreamUpdatesToKafkaWithTheCorrectType() throws InterruptedException {
+        final Configuration config = Configuration.copy(baseConfig)
+                .with("gcp.spanner.change.stream", changeStreamName)
+                .with("name", tableName + "_test")
+                .with("gcp.spanner.start.time",
+                        DateTimeFormatter.ISO_INSTANT.format(Instant.now()))
+                .build();
+        initializeConnectorTestFramework();
+        start(SpannerConnector.class, config);
+        assertConnectorIsRunning();
+        databaseConnection.executeUpdate("INSERT INTO " + tableName
+                + "(id, boolCol, int64Col, float32Col, float64Col, timestampCol,"
+                + " dateCol, stringCol, bytesCol, numericCol, jsonCol, arrCol) "
+                + "VALUES"
+                + " (1, true, 42, 3.14, 2.71, '1970-01-01 00:00:00 UTC',"
+                + "  '1970-01-01', 'stringVal', b'bytesVal', 6.023,"
+                + "  JSON '\"Hello\"', ['a', 'b'])");
+        waitForAvailableRecords(waitTimeForRecords(), TimeUnit.SECONDS);
+        SourceRecords sourceRecords = consumeRecordsByTopic(10, false);
+        List<SourceRecord> records = sourceRecords.recordsForTopic(getTopicName(config, tableName));
+        assertThat(records).hasSize(1);
+
+        Struct record = (Struct) (records.get(0).value());
+        assertThat(record.get("op")).isEqualTo("c");
+        assertThat(record.schema().field("after")).isNotNull();
+
+        Struct values = record.getStruct("after");
+
+        assertTrue(values.getBoolean("boolCol"));
+        assertThat(values.getInt64("int64Col")).isEqualTo(42);
+        // TODO: uncomment after emulator is released with the FLOAT32 support.
+        // assertThat(values.getFloat32("float32Col")).isEqualTo(3.14f);
+        assertThat(values.getFloat64("float64Col")).isEqualTo(2.71);
+        assertThat(values.getString("timestampCol")).isEqualTo("1970-01-01T00:00:00Z");
+        assertThat(values.getString("dateCol")).isEqualTo("1970-01-01");
+        assertThat(values.getString("stringCol")).isEqualTo("stringVal");
+        assertThat(values.getBytes("bytesCol")).isEqualTo("bytesVal".getBytes());
+        assertThat(values.getString("numericCol")).isEqualTo("6.023");
+        assertThat(values.getString("jsonCol")).isEqualTo("\"Hello\"");
+        assertThat(values.getArray("arrCol")).containsExactly("a", "b");
+
+        stopConnector();
+        assertConnectorNotRunning();
+    }
+}

--- a/src/test/java/io/debezium/connector/spanner/kafka/schema/mapper/FieldJsonNodeValueMapperTest.java
+++ b/src/test/java/io/debezium/connector/spanner/kafka/schema/mapper/FieldJsonNodeValueMapperTest.java
@@ -37,6 +37,11 @@ class FieldJsonNodeValueMapperTest {
                         OBJECT_MAPPER.readTree("{\"value\": [1.1, 2, 3.4] }").get("value"),
                         List.of(1.1, 2.0, 3.4)),
                 Arguments.of(
+                        ColumnTypeSchemaMapper.getSchema(ColumnTypeParser
+                                .parse("{\"array_element_type\":{\"code\":\"FLOAT32\"},\"code\":\"ARRAY\"}"), true),
+                        OBJECT_MAPPER.readTree("{\"value\": [1.1, 2, 3.4] }").get("value"),
+                        List.of(1.1f, 2.0f, 3.4f)),
+                Arguments.of(
                         ColumnTypeSchemaMapper.getSchema(ColumnTypeParser.parse("{\"code\":\"STRING\"}"), true),
                         OBJECT_MAPPER.readTree("{\"value\": \"test_string\" }").get("value"),
                         "test_string"),
@@ -52,6 +57,10 @@ class FieldJsonNodeValueMapperTest {
                         ColumnTypeSchemaMapper.getSchema(ColumnTypeParser.parse("{\"code\":\"FLOAT64\"}"), true),
                         OBJECT_MAPPER.readTree("{\"value\": 1.123 }").get("value"),
                         1.123),
+                Arguments.of(
+                        ColumnTypeSchemaMapper.getSchema(ColumnTypeParser.parse("{\"code\":\"FLOAT32\"}"), true),
+                        OBJECT_MAPPER.readTree("{\"value\": 1.123 }").get("value"),
+                        1.123f),
                 Arguments.of(
                         ColumnTypeSchemaMapper.getSchema(ColumnTypeParser.parse("{\"code\":\"BYTES\"}"), true),
                         OBJECT_MAPPER.readTree("{\"value\": \"test\" }").get("value"),

--- a/src/test/java/io/debezium/connector/spanner/kafka/schema/mapper/JsonNodeStructValueConvertorTest.java
+++ b/src/test/java/io/debezium/connector/spanner/kafka/schema/mapper/JsonNodeStructValueConvertorTest.java
@@ -43,6 +43,12 @@ class JsonNodeStructValueConvertorTest {
     }
 
     @Test
+    void getFloat() throws JsonProcessingException {
+        Assertions.assertEquals(1.123f,
+                JsonNodeStructValueConvertor.getFloat(OBJECT_MAPPER.readTree("{\"value\": 1.123 }").get("value")));
+    }
+
+    @Test
     void getBoolean() throws JsonProcessingException {
         Assertions.assertEquals(true,
                 JsonNodeStructValueConvertor.getBoolean(OBJECT_MAPPER.readTree("{\"value\": true }").get("value")));
@@ -60,5 +66,12 @@ class JsonNodeStructValueConvertorTest {
         Assertions.assertEquals(List.of(1.1, 2.0, 3.4),
                 JsonNodeStructValueConvertor.getList(OBJECT_MAPPER
                         .readTree("{\"value\": [1.1, 2, 3.4] }").get("value"), Schema.Type.FLOAT64));
+    }
+
+    @Test
+    void getFloatList() throws JsonProcessingException {
+        Assertions.assertEquals(List.of(1.1f, 2.0f, 3.4f),
+                JsonNodeStructValueConvertor.getList(OBJECT_MAPPER
+                        .readTree("{\"value\": [1.1, 2, 3.4] }").get("value"), Schema.Type.FLOAT32));
     }
 }

--- a/src/test/java/io/debezium/connector/spanner/util/Database.java
+++ b/src/test/java/io/debezium/connector/spanner/util/Database.java
@@ -28,6 +28,11 @@ public class Database {
             .generateDatabaseId()
             .build();
 
+    public static final Database TEST_PG_DATABASE = Database.builder()
+            .generateDatabaseId()
+            .dialect(Dialect.POSTGRESQL)
+            .build();
+
     public String getProjectId() {
         return projectId;
     }


### PR DESCRIPTION
FieldJsonNodeValueMapper changes are needed to read the FLOAT32 value from spanner's response.

This PR also adds the integration tests missed in #92.

Unfortunately the IT does not support verifying the float32 values, as it is dependent on a change in Cloud Spanner Emulator. The fix is already submitted there, and it should be available in the next few emulator releases. 
Note that this is a test-only issue; running this against production should pass the assertion.