### PR TITLE
DBZ-8564 Move away from dockerhub

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Maven build debezium core 
         run: mvn clean install -f core/pom.xml -pl debezium-bom,debezium-core,debezium-embedded,debezium-storage -am -DskipTests -DskipITs -Dformat.formatter.goal=validate -Dformat.imports.goal=check -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
       - name: Maven Package spanner connector core
-        run: mvn -B clean install
+        run: TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX=mirror.gcr.io/ mvn -B clean install
 #       - name: Maven unit tests
 #         run:  mvn test --batch-mode -Dmaven.test.failure.ignore=true
 # # Tests report

--- a/.github/workflows/ci-docker-image.yml
+++ b/.github/workflows/ci-docker-image.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Maven build debezium core 
         run: mvn clean install -f core/pom.xml -pl debezium-bom,debezium-core,debezium-embedded,debezium-storage -am -DskipTests -DskipITs -Dformat.formatter.goal=validate -Dformat.imports.goal=check -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
       - name: Maven build connector core
-        run: mvn -B clean install
+        run: TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX=mirror.gcr.io/ mvn -B clean install
 ## Add your DockerHub credantials to Aithub Actions        
         ##  secrets.DOCKER_USERNAME = username
         ##  secrets.DOCKER_PASSWORD = usertoken

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Maven build debezium core 
         run: mvn clean install -f core/pom.xml -pl debezium-bom,debezium-core,debezium-embedded,debezium-storage -am -DskipTests -DskipITs -Dformat.formatter.goal=validate -Dformat.imports.goal=check -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
       - name: Maven Package spanner connector core
-        run: mvn -B clean install
+        run: TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX=mirror.gcr.io/ mvn -B clean install
 ## Tests report
       - name: Report
         uses: dorny/test-reporter@v1

--- a/.github/workflows/cross-maven.yml
+++ b/.github/workflows/cross-maven.yml
@@ -69,4 +69,4 @@ jobs:
       - name: Maven build core
         run: ./spanner/mvnw clean install -f core/pom.xml -pl debezium-bom,debezium-core,debezium-embedded,debezium-storage -am -DskipTests -DskipITs -Dformat.formatter.goal=validate -Dformat.imports.goal=check -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
       - name: Maven build Spanner
-        run: ./spanner/mvnw clean install -f spanner/pom.xml -Passembly -Dformat.formatter.goal=validate -Dformat.imports.goal=check -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+        run: TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX=mirror.gcr.io/ ./spanner/mvnw clean install -f spanner/pom.xml -Passembly -Dformat.formatter.goal=validate -Dformat.imports.goal=check -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -43,4 +43,4 @@ jobs:
       - name: Build Debezium Core
         run: ./spanner/mvnw clean install -f core/pom.xml -pl debezium-bom,debezium-core,debezium-storage -am -DskipTests -DskipITs -Dformat.formatter.goal=validate -Dformat.imports.goal=check -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
       - name: Build Debezium Connector Spanner
-        run: ./spanner/mvnw clean install -f spanner/pom.xml -Passembly -Dformat.formatter.goal=validate -Dformat.imports.goal=check -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+        run: TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX=mirror.gcr.io/ ./spanner/mvnw clean install -f spanner/pom.xml -Passembly -Dformat.formatter.goal=validate -Dformat.imports.goal=check -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120


### PR DESCRIPTION
Integration tests use testcontainers Docker Compose which results into pulling `docker/compose` image. There doesn't seem to be a way how to force testconatiners to use different registry for this image, the only thing which seems to work is setting up env. variable `TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX`, which would result into pulls from dockerhub when e.g. building it manually wihtout setting this variable, but this is probably not a big issue. At least CI should avoid using dockerhub, as `TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX` is now set in GH actions.