### PR TITLE
DBZ-8610 Add snapshotSkipped implementation to reflect changes to the SnapshotProgressListener

### DIFF
--- a/src/main/java/io/debezium/connector/spanner/metrics/jmx/SpannerSnapshotChangeEventSourceMetricsStub.java
+++ b/src/main/java/io/debezium/connector/spanner/metrics/jmx/SpannerSnapshotChangeEventSourceMetricsStub.java
@@ -93,6 +93,11 @@ public class SpannerSnapshotChangeEventSourceMetricsStub implements SnapshotChan
     }
 
     @Override
+    public void snapshotSkipped(SpannerPartition partition) {
+        // spanner connector doesn't support snapshots
+    }
+
+    @Override
     public void dataCollectionSnapshotCompleted(SpannerPartition partition, DataCollectionId dataCollectionId, long numRows) {
         // spanner connector doesn't support snapshots
     }


### PR DESCRIPTION
Add snapshotSkipped implementation. 

The SnapshotProgressListener in debezium-core has a new metric whose method needs to be implemented in classes extending the interface. This change is dependent on the related PR in the debezium repository.

See https://issues.redhat.com/browse/DBZ-8610
See https://github.com/debezium/debezium/pull/6543