### PR TITLE
Mark gcp.spanner.credentials.json as PASSWORD type to prevent credential logging

### DIFF
--- a/src/main/java/io/debezium/connector/spanner/config/BaseSpannerConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/spanner/config/BaseSpannerConnectorConfig.java
@@ -196,7 +196,7 @@ public abstract class BaseSpannerConnectorConfig extends CommonConnectorConfig {
 
     public static final Field SPANNER_CREDENTIALS_JSON = Field.create(GCP_SPANNER_CREDENTIALS_JSON_PROPERTY_NAME)
             .withDisplayName(GCP_SPANNER_CREDENTIALS_JSON_PROPERTY_NAME)
-            .withType(Type.STRING)
+            .withType(Type.PASSWORD)
             .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR, 2))
             .withWidth(Width.LONG)
             .withImportance(Importance.MEDIUM)


### PR DESCRIPTION
## Summary
- Changed `SPANNER_CREDENTIALS_JSON` field type from `Type.STRING` to `Type.PASSWORD` in `BaseSpannerConnectorConfig.java`
- With `Type.STRING`, the full service account key JSON is logged in plaintext by Kafka Connect's config logging
- `Type.PASSWORD` tells Kafka Connect to mask the value as `[hidden]` in logs and config dumps, while `getString()` still returns the actual value — all existing code that reads the credential continues to work unchanged

## Test plan
- [ ] Verify connector starts successfully with `gcp.spanner.credentials.json` configured
- [ ] Confirm credential JSON is masked in Kafka Connect config logs
- [ ] Confirm `getString()` still returns the actual credential value for authentication

🤖 Generated with [Claude Code](https://claude.com/claude-code)