### PR TITLE
DBZ-1993 Batch partition offset resolution and add timeout protection

### DIFF
--- a/src/main/java/io/debezium/connector/spanner/SpannerConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/spanner/SpannerConnectorConfig.java
@@ -157,6 +157,10 @@ public class SpannerConnectorConfig extends BaseSpannerConnectorConfig {
         return getConfig().getInteger(STREAM_EVENT_QUEUE_CAPACITY, (int) STREAM_EVENT_QUEUE_CAPACITY.defaultValue());
     }
 
+    public long offsetBatchRetrievalTimeoutMs() {
+        return getConfig().getLong(OFFSET_BATCH_RETRIEVAL_TIMEOUT_MS, (long) OFFSET_BATCH_RETRIEVAL_TIMEOUT_MS.defaultValue());
+    }
+
     public String gcpSpannerCredentialsJson() {
         return getConfig().getString(GCP_SPANNER_CREDENTIALS_JSON_PROPERTY_NAME);
     }

--- a/src/main/java/io/debezium/connector/spanner/SpannerConnectorTask.java
+++ b/src/main/java/io/debezium/connector/spanner/SpannerConnectorTask.java
@@ -184,7 +184,8 @@ public class SpannerConnectorTask extends SpannerBaseSourceTask {
         final KafkaPartitionInfoProvider kafkaPartitionInfoProvider = new KafkaPartitionInfoProvider(adminClientFactory.getAdminClient());
 
         final PartitionOffsetProvider partitionOffsetProvider = new PartitionOffsetProvider(
-                this.context.offsetStorageReader(), spannerMeter.getMetricsEventPublisher());
+                this.context.offsetStorageReader(), spannerMeter.getMetricsEventPublisher(),
+                connectorConfig.offsetBatchRetrievalTimeoutMs());
 
         this.dispatcher = new SpannerEventDispatcher(
                 connectorConfig,

--- a/src/main/java/io/debezium/connector/spanner/config/BaseSpannerConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/spanner/config/BaseSpannerConnectorConfig.java
@@ -48,6 +48,7 @@ public abstract class BaseSpannerConnectorConfig extends CommonConnectorConfig {
     protected static final String GCP_SPANNER_CREDENTIALS_PATH_PROPERTY_NAME = "gcp.spanner.credentials.path";
     protected static final String GCP_SPANNER_CREDENTIALS_JSON_PROPERTY_NAME = "gcp.spanner.credentials.json";
     private static final String STREAM_EVENT_QUEUE_CAPACITY_PROPERTY_NAME = "gcp.spanner.stream.event.queue.capacity";
+    private static final String OFFSET_BATCH_RETRIEVAL_TIMEOUT_MS_PROPERTY_NAME = "gcp.spanner.offset.batch.retrieval.timeout.ms";
 
     private static final String TASK_STATE_CHANGE_EVENT_QUEUE_CAPACITY_PROPERTY_NAME = "connector.spanner.task.state.change.event.queue.capacity";
 
@@ -240,6 +241,16 @@ public abstract class BaseSpannerConnectorConfig extends CommonConnectorConfig {
             .withImportance(ConfigDef.Importance.MEDIUM)
             .withValidation(FieldValidator::isCorrectDateTime)
             .withDescription("End change stream time");
+
+    public static final Field OFFSET_BATCH_RETRIEVAL_TIMEOUT_MS = Field.create(OFFSET_BATCH_RETRIEVAL_TIMEOUT_MS_PROPERTY_NAME)
+            .withDisplayName("Batch offset retrieval timeout")
+            .withType(Type.LONG)
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR, 9))
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.LOW)
+            .withDefault(30000L)
+            .withValidation(Field::isPositiveLong)
+            .withDescription("Timeout in milliseconds for batch offset retrieval from Kafka Connect offset storage");
 
     public static final Field SPANNER_HEART_BEAT_INTERVAL = Heartbeat.HEARTBEAT_INTERVAL
             .withValidation(FieldValidator::isCorrectHeartBeatInterval)
@@ -598,6 +609,7 @@ public abstract class BaseSpannerConnectorConfig extends CommonConnectorConfig {
                     SPANNER_HOST,
                     SPANNER_EMULATOR_HOST,
                     STREAM_EVENT_QUEUE_CAPACITY,
+                    OFFSET_BATCH_RETRIEVAL_TIMEOUT_MS,
                     TASK_STATE_CHANGE_EVENT_QUEUE_CAPACITY,
                     VALUE_CAPTURE_MODE,
                     SPANNER_HEART_BEAT_INTERVAL,

--- a/src/main/java/io/debezium/connector/spanner/context/offset/PartitionOffset.java
+++ b/src/main/java/io/debezium/connector/spanner/context/offset/PartitionOffset.java
@@ -36,7 +36,7 @@ public class PartitionOffset {
 
     public Map<String, String> getOffset() {
         if (this.offset == null) {
-            return null;
+            return Map.of();
         }
         return Map.of(OFFSET_KEY, offset.toString(),
                 DEBUG_START_TIME_KEY, metadata.getPartitionStartTimestamp().toString(),

--- a/src/main/java/io/debezium/connector/spanner/task/PartitionFactory.java
+++ b/src/main/java/io/debezium/connector/spanner/task/PartitionFactory.java
@@ -7,8 +7,11 @@ package io.debezium.connector.spanner.task;
 
 import static org.slf4j.LoggerFactory.getLogger;
 
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 
@@ -50,43 +53,58 @@ public class PartitionFactory {
         return partition;
     }
 
+    public Map<String, Partition> getPartitions(List<PartitionState> partitionStates) {
+        List<String> tokens = partitionStates.stream()
+                .map(PartitionState::getToken)
+                .collect(Collectors.toList());
+
+        Map<String, Timestamp> offsets = partitionOffsetProvider.getOffsets(tokens);
+
+        Map<String, Partition> partitionMap = new HashMap<>();
+        for (PartitionState partitionState : partitionStates) {
+            Timestamp offset = offsets.get(partitionState.getToken());
+            Timestamp startTime = resolveOffset(partitionState, offset);
+
+            partitionMap.put(partitionState.getToken(), Partition.builder()
+                    .token(partitionState.getToken())
+                    .startTimestamp(startTime)
+                    .endTimestamp(partitionState.getEndTimestamp())
+                    .parentTokens(partitionState.getParents())
+                    .build());
+        }
+        return partitionMap;
+    }
+
     public Partition getPartition(PartitionState partitionState) {
+        Timestamp offset = partitionOffsetProvider.getOffset(partitionState);
         return Partition.builder()
                 .token(partitionState.getToken())
-                .startTimestamp(getOffset(partitionState))
+                .startTimestamp(resolveOffset(partitionState, offset))
                 .endTimestamp(partitionState.getEndTimestamp())
                 .parentTokens(partitionState.getParents())
                 .build();
     }
 
-    private Timestamp getOffset(PartitionState partitionState) {
-        final Timestamp offset = partitionOffsetProvider.getOffset(partitionState);
+    private Timestamp resolveOffset(PartitionState partitionState, Timestamp offset) {
         Timestamp startTime;
 
         if (offset != null) {
-
             if (offset.toSqlTimestamp().before(partitionState.getStartTimestamp().toSqlTimestamp())) {
-                Map<String, String> offsetMap = partitionOffsetProvider.getOffsetMap(partitionState);
-
-                LOGGER.warn("Incorrect offset, start time will be taken for partition {}, offsetMap {}", partitionState.getToken(), offsetMap);
-
+                LOGGER.warn("Incorrect offset {}, start time will be taken for partition {}", offset, partitionState.getToken());
                 startTime = partitionState.getStartTimestamp();
             }
             else {
                 LOGGER.info("Found previous offset {}", Map.of(partitionState.getToken(), offset.toString()));
-
                 startTime = offset;
             }
         }
         else {
             LOGGER.info("Previous offset not found, start time will be taken {}",
                     Map.of(partitionState.getToken(), partitionState.getStartTimestamp()));
-
             startTime = partitionState.getStartTimestamp();
         }
 
         metricsEventPublisher.publishMetricEvent(PartitionOffsetLagMetricEvent.from(partitionState.getToken(), startTime));
-
         return startTime;
     }
 }

--- a/src/main/java/io/debezium/connector/spanner/task/PartitionOffsetProvider.java
+++ b/src/main/java/io/debezium/connector/spanner/task/PartitionOffsetProvider.java
@@ -40,12 +40,15 @@ public class PartitionOffsetProvider {
 
     private final OffsetStorageReader offsetStorageReader;
     private final MetricsEventPublisher metricsEventPublisher;
+    private final long batchRetrievalTimeoutMs;
 
     private final ExecutorService executor;
 
-    public PartitionOffsetProvider(OffsetStorageReader offsetStorageReader, MetricsEventPublisher metricsEventPublisher) {
+    public PartitionOffsetProvider(OffsetStorageReader offsetStorageReader, MetricsEventPublisher metricsEventPublisher,
+                                   long batchRetrievalTimeoutMs) {
         this.offsetStorageReader = offsetStorageReader;
         this.metricsEventPublisher = metricsEventPublisher;
+        this.batchRetrievalTimeoutMs = batchRetrievalTimeoutMs;
         this.executor = Executors.newCachedThreadPool();
     }
 
@@ -72,7 +75,7 @@ public class PartitionOffsetProvider {
         Future<Map<Map<String, String>, Map<String, Object>>> future = executor.submit(
                 () -> this.offsetStorageReader.offsets(partitionsMapList));
         try {
-            result = future.get(30, TimeUnit.SECONDS);
+            result = future.get(batchRetrievalTimeoutMs, TimeUnit.MILLISECONDS);
         }
         catch (TimeoutException ex) {
             LOGGER.error("Failed to retrieve batch offsets for {} partitions in time", partitions.size(), ex);

--- a/src/main/java/io/debezium/connector/spanner/task/PartitionOffsetProvider.java
+++ b/src/main/java/io/debezium/connector/spanner/task/PartitionOffsetProvider.java
@@ -61,17 +61,6 @@ public class PartitionOffsetProvider {
         return PartitionOffset.extractOffset(result);
     }
 
-    public Map<String, String> getOffsetMap(PartitionState token) {
-
-        Map<String, String> spannerPartition = new SpannerPartition(token.getToken()).getSourcePartition();
-        Map<String, ?> result = retrieveOffsetMap(spannerPartition);
-
-        if (result == null) {
-            return Map.of();
-        }
-        return (Map<String, String>) result;
-    }
-
     public Map<String, Timestamp> getOffsets(Collection<String> partitions) {
         Instant startTime = Instant.now();
 
@@ -79,7 +68,28 @@ public class PartitionOffsetProvider {
                 .map(token -> new SpannerPartition(token).getSourcePartition())
                 .collect(Collectors.toList());
 
-        Map<Map<String, String>, Map<String, Object>> result = this.offsetStorageReader.offsets(partitionsMapList);
+        Map<Map<String, String>, Map<String, Object>> result;
+        Future<Map<Map<String, String>, Map<String, Object>>> future = executor.submit(
+                () -> this.offsetStorageReader.offsets(partitionsMapList));
+        try {
+            result = future.get(30, TimeUnit.SECONDS);
+        }
+        catch (TimeoutException ex) {
+            LOGGER.error("Failed to retrieve batch offsets for {} partitions in time", partitions.size(), ex);
+            future.cancel(true);
+            return Map.of();
+        }
+        catch (InterruptedException e) {
+            LOGGER.error("Interrupted while retrieving batch offsets for {} partitions", partitions.size(), e);
+            future.cancel(true);
+            Thread.currentThread().interrupt();
+            return Map.of();
+        }
+        catch (ExecutionException e) {
+            LOGGER.error("Failed to retrieve batch offsets for {} partitions: {}", partitions.size(), e.toString(), e);
+            future.cancel(true);
+            return Map.of();
+        }
 
         if (result == null) {
             return Map.of();

--- a/src/main/java/io/debezium/connector/spanner/task/operation/TakePartitionForStreamingOperation.java
+++ b/src/main/java/io/debezium/connector/spanner/task/operation/TakePartitionForStreamingOperation.java
@@ -8,6 +8,7 @@ package io.debezium.connector.spanner.task.operation;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -54,9 +55,12 @@ public class TakePartitionForStreamingOperation implements Operation {
         try {
             Set<String> toSchedule = new HashSet<>();
 
+            Map<String, Partition> partitionMap = partitionFactory.getPartitions(toStreaming);
+
             toStreaming.forEach(partitionState -> {
                 LOGGER.info("Task {}, submitting the partition for streaming {}", taskSyncContext.getTaskUid(), partitionState);
-                if (this.submitPartition(partitionState, taskSyncContext)) {
+                Partition partition = partitionMap.get(partitionState.getToken());
+                if (partition != null && changeStream.submitPartition(partition)) {
                     toSchedule.add(partitionState.getToken());
                 }
                 else {
@@ -89,13 +93,6 @@ public class TakePartitionForStreamingOperation implements Operation {
         finally {
             LOGGER.debug("Task {}, finished trying to take partitions for streaming {}", taskSyncContext.getTaskUid());
         }
-    }
-
-    private boolean submitPartition(PartitionState partitionState, TaskSyncContext taskSyncContext) {
-
-        Partition partition = partitionFactory.getPartition(partitionState);
-
-        return changeStream.submitPartition(partition);
     }
 
     private TaskSyncContext removeAlreadyStreamingPartitions(TaskSyncContext taskSyncContext) {

--- a/src/test/java/io/debezium/connector/spanner/SpannerConnectorTest.java
+++ b/src/test/java/io/debezium/connector/spanner/SpannerConnectorTest.java
@@ -132,7 +132,7 @@ class SpannerConnectorTest {
     void testConfig() {
         ConfigDef actualConfigResult = new SpannerConnector().config();
         Map<String, ConfigDef.ConfigKey> configKeysResult = actualConfigResult.configKeys();
-        assertEquals(57, configKeysResult.size());
+        assertEquals(58, configKeysResult.size());
         List<String> groupsResult = actualConfigResult.groups();
         assertEquals(3, groupsResult.size());
         assertEquals("Spanner", groupsResult.get(0));

--- a/src/test/java/io/debezium/connector/spanner/config/BaseSpannerConnectorConfigTest.java
+++ b/src/test/java/io/debezium/connector/spanner/config/BaseSpannerConnectorConfigTest.java
@@ -32,7 +32,7 @@ class BaseSpannerConnectorConfigTest {
     void testConfigDef() {
         ConfigDef actualConfigDefResult = BaseSpannerConnectorConfig.configDef();
         Map<String, ConfigDef.ConfigKey> configKeysResult = actualConfigDefResult.configKeys();
-        assertEquals(57, configKeysResult.size());
+        assertEquals(58, configKeysResult.size());
         List<String> groupsResult = actualConfigDefResult.groups();
         assertEquals(3, groupsResult.size());
         assertEquals("Spanner", groupsResult.get(0));

--- a/src/test/java/io/debezium/connector/spanner/task/PartitionFactoryTest.java
+++ b/src/test/java/io/debezium/connector/spanner/task/PartitionFactoryTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.spanner.task;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.kafka.connect.storage.OffsetStorageReader;
+import org.junit.jupiter.api.Test;
+
+import com.google.cloud.Timestamp;
+
+import io.debezium.connector.spanner.db.model.Partition;
+import io.debezium.connector.spanner.kafka.internal.model.PartitionState;
+import io.debezium.connector.spanner.kafka.internal.model.PartitionStateEnum;
+import io.debezium.connector.spanner.metrics.MetricsEventPublisher;
+
+class PartitionFactoryTest {
+
+    private static final Timestamp START = Timestamp.parseTimestamp("2026-01-01T00:00:00Z");
+    private static final Timestamp OFFSET = Timestamp.parseTimestamp("2026-01-01T00:05:00Z");
+
+    private PartitionState buildPartitionState(String token) {
+        return PartitionState.builder()
+                .token(token)
+                .startTimestamp(START)
+                .endTimestamp(null)
+                .state(PartitionStateEnum.READY_FOR_STREAMING)
+                .parents(Set.of())
+                .build();
+    }
+
+    private PartitionFactory buildFactory(Map<Map<String, String>, Map<String, Object>> offsets) {
+        OffsetStorageReader reader = mock(OffsetStorageReader.class);
+        when(reader.offsets(any())).thenAnswer(invocation -> offsets);
+
+        MetricsEventPublisher metricsPublisher = new MetricsEventPublisher();
+        PartitionOffsetProvider offsetProvider = new PartitionOffsetProvider(reader, metricsPublisher);
+        return new PartitionFactory(offsetProvider, metricsPublisher);
+    }
+
+    @Test
+    void testGetPartitionsBatchResolution() {
+        Map<Map<String, String>, Map<String, Object>> offsets = new HashMap<>();
+        offsets.put(Map.of("partitionToken", "token1"), Map.of("offset", OFFSET.toString()));
+        offsets.put(Map.of("partitionToken", "token2"), Map.of("offset", OFFSET.toString()));
+
+        PartitionFactory factory = buildFactory(offsets);
+
+        List<PartitionState> states = List.of(buildPartitionState("token1"), buildPartitionState("token2"));
+        Map<String, Partition> result = factory.getPartitions(states);
+
+        assertEquals(2, result.size());
+        assertNotNull(result.get("token1"));
+        assertNotNull(result.get("token2"));
+        assertEquals(OFFSET, result.get("token1").getStartTimestamp());
+        assertEquals(OFFSET, result.get("token2").getStartTimestamp());
+    }
+
+    @Test
+    void testGetPartitionsWithNullOffset() {
+        PartitionFactory factory = buildFactory(new HashMap<>());
+
+        List<PartitionState> states = List.of(buildPartitionState("token1"));
+        Map<String, Partition> result = factory.getPartitions(states);
+
+        assertEquals(1, result.size());
+        assertEquals(START, result.get("token1").getStartTimestamp());
+    }
+
+    @Test
+    void testGetPartitionsWithIncorrectOffset() {
+        Timestamp beforeStart = Timestamp.parseTimestamp("2025-12-31T00:00:00Z");
+        Map<Map<String, String>, Map<String, Object>> offsets = new HashMap<>();
+        offsets.put(Map.of("partitionToken", "token1"), Map.of("offset", beforeStart.toString()));
+
+        PartitionFactory factory = buildFactory(offsets);
+
+        List<PartitionState> states = List.of(buildPartitionState("token1"));
+        Map<String, Partition> result = factory.getPartitions(states);
+
+        assertEquals(1, result.size());
+        assertEquals(START, result.get("token1").getStartTimestamp());
+    }
+}

--- a/src/test/java/io/debezium/connector/spanner/task/PartitionFactoryTest.java
+++ b/src/test/java/io/debezium/connector/spanner/task/PartitionFactoryTest.java
@@ -46,7 +46,7 @@ class PartitionFactoryTest {
         when(reader.offsets(any())).thenAnswer(invocation -> offsets);
 
         MetricsEventPublisher metricsPublisher = new MetricsEventPublisher();
-        PartitionOffsetProvider offsetProvider = new PartitionOffsetProvider(reader, metricsPublisher);
+        PartitionOffsetProvider offsetProvider = new PartitionOffsetProvider(reader, metricsPublisher, 30000L);
         return new PartitionFactory(offsetProvider, metricsPublisher);
     }
 

--- a/src/test/java/io/debezium/connector/spanner/task/PartitionOffsetProviderTest.java
+++ b/src/test/java/io/debezium/connector/spanner/task/PartitionOffsetProviderTest.java
@@ -37,7 +37,7 @@ class PartitionOffsetProviderTest {
 
         when(reader.offsets(any())).thenAnswer(invocation -> offsets);
 
-        PartitionOffsetProvider provider = new PartitionOffsetProvider(reader, metricsPublisher);
+        PartitionOffsetProvider provider = new PartitionOffsetProvider(reader, metricsPublisher, 30000L);
         Map<String, Timestamp> result = provider.getOffsets(List.of("token1"));
 
         assertEquals(1, result.size());
@@ -51,7 +51,7 @@ class PartitionOffsetProviderTest {
 
         when(reader.offsets(any())).thenAnswer(invocation -> null);
 
-        PartitionOffsetProvider provider = new PartitionOffsetProvider(reader, metricsPublisher);
+        PartitionOffsetProvider provider = new PartitionOffsetProvider(reader, metricsPublisher, 30000L);
         Map<String, Timestamp> result = provider.getOffsets(List.of("token1"));
 
         assertTrue(result.isEmpty());
@@ -67,7 +67,7 @@ class PartitionOffsetProviderTest {
             return null;
         });
 
-        PartitionOffsetProvider provider = new PartitionOffsetProvider(reader, metricsPublisher);
+        PartitionOffsetProvider provider = new PartitionOffsetProvider(reader, metricsPublisher, 30000L);
         Map<String, Timestamp> result = provider.getOffsets(List.of("token1"));
 
         assertTrue(result.isEmpty());

--- a/src/test/java/io/debezium/connector/spanner/task/PartitionOffsetProviderTest.java
+++ b/src/test/java/io/debezium/connector/spanner/task/PartitionOffsetProviderTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.spanner.task;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.connect.storage.OffsetStorageReader;
+import org.junit.jupiter.api.Test;
+
+import com.google.cloud.Timestamp;
+
+import io.debezium.connector.spanner.metrics.MetricsEventPublisher;
+
+class PartitionOffsetProviderTest {
+
+    @Test
+    void testGetOffsetsReturnsOffsets() {
+        OffsetStorageReader reader = mock(OffsetStorageReader.class);
+        MetricsEventPublisher metricsPublisher = new MetricsEventPublisher();
+
+        Timestamp expected = Timestamp.parseTimestamp("2026-01-01T00:05:00Z");
+        Map<String, String> partitionKey = Map.of("partitionToken", "token1");
+        Map<String, Object> offsetValue = Map.of("offset", expected.toString());
+        Map<Map<String, String>, Map<String, Object>> offsets = new HashMap<>();
+        offsets.put(partitionKey, offsetValue);
+
+        when(reader.offsets(any())).thenAnswer(invocation -> offsets);
+
+        PartitionOffsetProvider provider = new PartitionOffsetProvider(reader, metricsPublisher);
+        Map<String, Timestamp> result = provider.getOffsets(List.of("token1"));
+
+        assertEquals(1, result.size());
+        assertEquals(expected, result.get("token1"));
+    }
+
+    @Test
+    void testGetOffsetsReturnsEmptyOnNull() {
+        OffsetStorageReader reader = mock(OffsetStorageReader.class);
+        MetricsEventPublisher metricsPublisher = new MetricsEventPublisher();
+
+        when(reader.offsets(any())).thenAnswer(invocation -> null);
+
+        PartitionOffsetProvider provider = new PartitionOffsetProvider(reader, metricsPublisher);
+        Map<String, Timestamp> result = provider.getOffsets(List.of("token1"));
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testGetOffsetsReturnsEmptyOnTimeout() {
+        OffsetStorageReader reader = mock(OffsetStorageReader.class);
+        MetricsEventPublisher metricsPublisher = new MetricsEventPublisher();
+
+        when(reader.offsets(any())).thenAnswer(invocation -> {
+            Thread.sleep(60_000);
+            return null;
+        });
+
+        PartitionOffsetProvider provider = new PartitionOffsetProvider(reader, metricsPublisher);
+        Map<String, Timestamp> result = provider.getOffsets(List.of("token1"));
+
+        assertTrue(result.isEmpty());
+    }
+}


### PR DESCRIPTION
Fixes debezium/dbz#1993

## Description

- Add `PartitionFactory.getPartitions()` to resolve all partition offsets in a single batch call to the offset storage
- Wire `TakePartitionForStreamingOperation` to use the batch path instead of per-partition lookups
- Add 30-second timeout on the batch `offsetStorageReader.offsets()` call, matching the timeout pattern already used on the single-partition path
- Remove dead `getOffsetMap()` from `PartitionOffsetProvider`
- Return empty map instead of null from `PartitionOffset.getOffset()` to prevent downstream NPEs
