### PR TITLE
DBZ-1869 Fix credential leakage in Spanner connector logs

### DIFF
--- a/src/main/java/io/debezium/connector/spanner/SpannerConnector.java
+++ b/src/main/java/io/debezium/connector/spanner/SpannerConnector.java
@@ -52,7 +52,7 @@ public class SpannerConnector extends SourceConnector {
     public void start(Map<String, String> props) {
         this.props = props;
 
-        LOGGER.info("Starting connector: props {}", props);
+        LOGGER.info("Starting connector");
 
         final SpannerConnectorConfig config = new SpannerConnectorConfig(Configuration.from(props));
 

--- a/src/main/java/io/debezium/connector/spanner/config/BaseSpannerConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/spanner/config/BaseSpannerConnectorConfig.java
@@ -196,7 +196,7 @@ public abstract class BaseSpannerConnectorConfig extends CommonConnectorConfig {
 
     public static final Field SPANNER_CREDENTIALS_JSON = Field.create(GCP_SPANNER_CREDENTIALS_JSON_PROPERTY_NAME)
             .withDisplayName(GCP_SPANNER_CREDENTIALS_JSON_PROPERTY_NAME)
-            .withType(Type.STRING)
+            .withType(Type.PASSWORD)
             .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR, 2))
             .withWidth(Width.LONG)
             .withImportance(Importance.MEDIUM)

--- a/src/main/java/io/debezium/connector/spanner/db/DatabaseClientFactory.java
+++ b/src/main/java/io/debezium/connector/spanner/db/DatabaseClientFactory.java
@@ -92,7 +92,7 @@ public class DatabaseClientFactory {
                 credential = GoogleCredentials.fromStream(new ByteArrayInputStream(credentialsJson.getBytes()));
             }
             catch (IOException ex) {
-                LOGGER.error("Error read GOOGLE CREDENTIALS from params {}", credentialsJson);
+                LOGGER.error("Error reading Google credentials from JSON parameter");
                 LOGGER.error(ex.getMessage(), ex);
             }
         }
@@ -101,7 +101,7 @@ public class DatabaseClientFactory {
                 credential = GoogleCredentials.fromStream(new FileInputStream(credentialsPath));
             }
             catch (IOException e) {
-                LOGGER.error("Error read GOOGLE CREDENTIALS from path {}", credentialsPath);
+                LOGGER.error("Error reading Google credentials from file path");
                 LOGGER.error(e.getMessage(), e);
             }
         }


### PR DESCRIPTION
Fixes debezium/dbz#1869

## Description

- Remove full connector props from the startup log in `SpannerConnector.java` to prevent logging sensitive config values (GCP credentials, SASL secrets, etc.)
- Change `gcp.spanner.credentials.json` field type from `Type.STRING` to `Type.PASSWORD` in `BaseSpannerConnectorConfig.java` so the Kafka Connect framework masks this value in REST API responses and framework-level logging
- Remove raw credentials JSON from the error log in `DatabaseClientFactory.java` on credential parse failure
- Remove credentials file path from the error log on file read failure

Note: The `PASSWORD_PATTERN` fix in Debezium core `Configuration.java` (adding `.*credentials\.json$` to the masking regex) will be addressed in a separate PR against `debezium/debezium`.
