### PR TITLE
debezium/dbz#2062 Convert CommittedRecord class to Java record

### DIFF
--- a/src/main/java/io/debezium/connector/spanner/CommittedRecord.java
+++ b/src/main/java/io/debezium/connector/spanner/CommittedRecord.java
@@ -5,20 +5,5 @@
  */
 package io.debezium.connector.spanner;
 
-public class CommittedRecord {
-    private final String token;
-    private final String recordUid;
-
-    public CommittedRecord(String token, String recordUid) {
-        this.token = token;
-        this.recordUid = recordUid;
-    }
-
-    public String getToken() {
-        return token;
-    }
-
-    public String getRecordUid() {
-        return recordUid;
-    }
+public record CommittedRecord(String token, String recordUid) {
 }

--- a/src/main/java/io/debezium/connector/spanner/SpannerStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/spanner/SpannerStreamingChangeEventSource.java
@@ -331,7 +331,7 @@ public class SpannerStreamingChangeEventSource implements CommittingRecordsStrea
         }
 
         for (CommittedRecord record : records) {
-            this.finishingPartitionManager.commitRecord(record.getToken(), record.getRecordUid());
+            this.finishingPartitionManager.commitRecord(record.token(), record.recordUid());
         }
     }
 


### PR DESCRIPTION
Fixes debezium/dbz#2062

## Summary

Converts `CommittedRecord` from a manual class to a Java `record`, as suggested in [this review comment](https://github.com/debezium/debezium-connector-spanner/pull/158#issuecomment-4621866197).

- `CommittedRecord` is an immutable data carrier with two fields — a Java `record` is the idiomatic fit
- Updates accessor calls from `getToken()`/`getRecordUid()` to `token()`/`recordUid()`
- No behavioral or runtime changes

Follow-up to debezium/dbz#1992.