### PR TITLE
debezium/dbz#1415 Fix Dockerfile build and permission issues for GKE deployment

### DIFF
--- a/src/test/docker/Dockerfile
+++ b/src/test/docker/Dockerfile
@@ -1,9 +1,9 @@
 FROM mirror.gcr.io/confluentinc/cp-kafka-connect-base
 ARG projectVersion
 USER root
-RUN yum remove -y zulu11-ca-jdk-headless && yum remove -y zulu11-ca-jre-headless
-RUN yum install -y zulu17-ca-jdk-headless && yum install -y zulu17-ca-jre-headless
-USER appuser
-COPY target/debezium-connector-spanner-${projectVersion}-plugin/ /usr/share/java/google-debezium-connector-spanner/
+COPY target/debezium-connector-spanner-${projectVersion}-plugin/debezium-connector-spanner/ /usr/share/java/google-debezium-connector-spanner/
 COPY src/test/docker/jmx_prometheus_javaagent-0.16.1.jar /usr/share/prometheus/jmx_prometheus_javaagent.jar
 COPY src/test/docker/metrics-config.yml /usr/share/prometheus/metrics-config.yml
+RUN chown -R appuser:appuser /usr/share/java/google-debezium-connector-spanner/
+RUN chown -R appuser:appuser /usr/share/prometheus/
+USER appuser


### PR DESCRIPTION
Fixes debezium/dbz#1415

- Simplify build by using the pre-installed Java 21 in the base image and removing Java 11/17 installation steps (which failed on minimal images lacking yum/dnf).
- Flatten the plugin copy directory structure to ensure correct classpath scanning by Kafka Connect.
- Grant ownership of copied files to 'appuser' (the non-root container runtime user) to prevent ClassNotFoundException caused by restrictive file permissions.

Supersedes #166 