### PR TITLE
debezium/dbz#2523 Fail partition read when stream ends without child partitions

### DIFF
--- a/src/main/java/io/debezium/connector/spanner/db/stream/SpannerChangeStream.java
+++ b/src/main/java/io/debezium/connector/spanner/db/stream/SpannerChangeStream.java
@@ -227,6 +227,10 @@ public class SpannerChangeStream implements ChangeStream {
 
     @VisibleForTesting
     ChangeStreamException getStreamException(Partition partition, Exception ex) {
+        if (ex instanceof ChangeStreamException) {
+            return (ChangeStreamException) ex;
+        }
+
         if (ex instanceof SpannerException) {
             SpannerException spannerException = (SpannerException) ex;
 

--- a/src/main/java/io/debezium/connector/spanner/db/stream/SpannerChangeStreamService.java
+++ b/src/main/java/io/debezium/connector/spanner/db/stream/SpannerChangeStreamService.java
@@ -12,6 +12,8 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.cloud.Timestamp;
+
 import io.debezium.connector.spanner.db.dao.ChangeStreamDao;
 import io.debezium.connector.spanner.db.dao.ChangeStreamResultSet;
 import io.debezium.connector.spanner.db.mapper.ChangeStreamRecordMapper;
@@ -20,6 +22,7 @@ import io.debezium.connector.spanner.db.model.event.ChangeStreamEvent;
 import io.debezium.connector.spanner.db.model.event.ChildPartitionsEvent;
 import io.debezium.connector.spanner.db.model.event.FinishPartitionEvent;
 import io.debezium.connector.spanner.db.model.event.HeartbeatEvent;
+import io.debezium.connector.spanner.db.stream.exception.ChangeStreamException;
 import io.debezium.connector.spanner.metrics.MetricsEventPublisher;
 import io.debezium.connector.spanner.metrics.event.DelayChangeStreamEventsMetricEvent;
 
@@ -55,6 +58,8 @@ public class SpannerChangeStreamService {
         partitionEventListener.onRun(partition);
 
         LOGGER.info("Task: {}, Streaming {} from {} to {}", taskUid, token, partition.getStartTimestamp(), partition.getEndTimestamp());
+        Timestamp lastReceivedTimestamp = null;
+        boolean receivedChildPartitions = false;
         try (ChangeStreamResultSet resultSet = changeStreamDao.streamQuery(token, partition.getStartTimestamp(),
                 partition.getEndTimestamp(), heartbeatMillis.toMillis())) {
 
@@ -66,6 +71,17 @@ public class SpannerChangeStreamService {
                         partition,
                         resultSet, resultSet.getMetadata());
                 LOGGER.debug("Task: {}, Events receive from stream: {}", taskUid, events);
+
+                for (ChangeStreamEvent event : events) {
+                    if (event instanceof ChildPartitionsEvent) {
+                        receivedChildPartitions = true;
+                    }
+                    if (event.getRecordTimestamp() != null) {
+                        if (lastReceivedTimestamp == null || event.getRecordTimestamp().compareTo(lastReceivedTimestamp) > 0) {
+                            lastReceivedTimestamp = event.getRecordTimestamp();
+                        }
+                    }
+                }
 
                 if (!events.isEmpty() && (events.get(0) instanceof HeartbeatEvent)) {
                     var heartbeatEvent = (HeartbeatEvent) events.get(0);
@@ -89,6 +105,21 @@ public class SpannerChangeStreamService {
         catch (InterruptedException ex) {
             LOGGER.info("task {}, Interrupting streaming partition task with token {}", this.taskUid, partition.getToken());
             Thread.currentThread().interrupt();
+            return;
+        }
+
+        boolean reachedEnd = receivedChildPartitions
+                || (partition.getEndTimestamp() != null
+                        && lastReceivedTimestamp != null
+                        && lastReceivedTimestamp.compareTo(partition.getEndTimestamp()) >= 0);
+
+        if (!reachedEnd) {
+            LOGGER.error(
+                    "Task: {}, Partition {} stream ended without delivering child partition records or reaching end timestamp {} (last received timestamp: {})! Retrying partition stream.",
+                    taskUid, token, partition.getEndTimestamp(), lastReceivedTimestamp);
+            throw new ChangeStreamException(
+                    "Partition " + token + " stream ended without child partitions or reaching end timestamp "
+                            + partition.getEndTimestamp() + ". Retrying partition stream.");
         }
 
         partitionEventListener.onFinish(partition);

--- a/src/test/java/io/debezium/connector/spanner/db/stream/SpannerChangeStreamServiceTest.java
+++ b/src/test/java/io/debezium/connector/spanner/db/stream/SpannerChangeStreamServiceTest.java
@@ -5,26 +5,34 @@
  */
 package io.debezium.connector.spanner.db.stream;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.Duration;
 import java.util.HashSet;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
 import com.google.cloud.Timestamp;
-import com.google.cloud.spanner.DatabaseClient;
-import com.google.cloud.spanner.Dialect;
 
 import io.debezium.connector.spanner.db.dao.ChangeStreamDao;
 import io.debezium.connector.spanner.db.dao.ChangeStreamResultSet;
 import io.debezium.connector.spanner.db.mapper.ChangeStreamRecordMapper;
 import io.debezium.connector.spanner.db.model.Partition;
+import io.debezium.connector.spanner.db.model.StreamEventMetadata;
+import io.debezium.connector.spanner.db.model.event.ChildPartitionsEvent;
+import io.debezium.connector.spanner.db.model.event.FinishPartitionEvent;
+import io.debezium.connector.spanner.db.model.event.HeartbeatEvent;
+import io.debezium.connector.spanner.db.stream.exception.ChangeStreamException;
 import io.debezium.connector.spanner.metrics.MetricsEventPublisher;
 
 class SpannerChangeStreamServiceTest {
@@ -33,25 +41,140 @@ class SpannerChangeStreamServiceTest {
     void testGetEvents() throws InterruptedException, Exception {
         ChangeStreamDao changeStreamDao = mock(ChangeStreamDao.class);
         ChangeStreamResultSet changeStreamResultSet = mock(ChangeStreamResultSet.class);
+        ChangeStreamRecordMapper mapper = mock(ChangeStreamRecordMapper.class);
         MetricsEventPublisher metricsEventPublisher = mock(MetricsEventPublisher.class);
-        when(changeStreamResultSet.next()).thenReturn(false);
-        when(changeStreamDao.streamQuery(any(), any(), any(), anyLong())).thenReturn(changeStreamResultSet);
 
-        DatabaseClient gsqlDatabaseClient = mock(DatabaseClient.class);
-        when(gsqlDatabaseClient.getDialect()).thenReturn(Dialect.GOOGLE_STANDARD_SQL);
+        Timestamp endTimestamp = Timestamp.ofTimeMicroseconds(100L);
+        HeartbeatEvent heartbeatEvent = new HeartbeatEvent(endTimestamp, mock(StreamEventMetadata.class));
+        when(changeStreamResultSet.next()).thenReturn(true, false);
+        when(changeStreamDao.streamQuery(any(), any(), any(), anyLong())).thenReturn(changeStreamResultSet);
+        when(mapper.toChangeStreamEvents(any(), any(), any())).thenReturn(List.of(heartbeatEvent));
+
         SpannerChangeStreamService spannerChangeStreamService = new SpannerChangeStreamService("TaskUid", changeStreamDao,
-                new ChangeStreamRecordMapper(gsqlDatabaseClient, false), Duration.ofMillis(1000),
-                metricsEventPublisher);
+                mapper, Duration.ofMillis(1000), metricsEventPublisher);
 
         HashSet<String> parentTokens = new HashSet<>();
         Timestamp startTimestamp = Timestamp.ofTimeMicroseconds(1L);
-        Partition partition = new Partition("token", parentTokens, startTimestamp, Timestamp.ofTimeMicroseconds(1L), "originParent");
+        Partition partition = new Partition("token", parentTokens, startTimestamp, endTimestamp, "originParent");
 
         ChangeStreamEventConsumer changeStreamEventConsumer = mock(ChangeStreamEventConsumer.class);
         PartitionEventListener partitionEventListener = mock(PartitionEventListener.class);
         doNothing().when(partitionEventListener).onRun(any());
+        doNothing().when(partitionEventListener).onFinish(any());
+
         spannerChangeStreamService.getEvents(partition, changeStreamEventConsumer, partitionEventListener);
 
-        verify(changeStreamEventConsumer).acceptChangeStreamEvent(any());
+        verify(changeStreamEventConsumer).acceptChangeStreamEvent(heartbeatEvent);
+        verify(changeStreamEventConsumer).acceptChangeStreamEvent(any(FinishPartitionEvent.class));
+        verify(partitionEventListener).onFinish(partition);
+    }
+
+    @Test
+    void testStreamEndingWithoutChildPartitionsThrowsException() throws Exception {
+        ChangeStreamDao changeStreamDao = mock(ChangeStreamDao.class);
+        ChangeStreamResultSet changeStreamResultSet = mock(ChangeStreamResultSet.class);
+        ChangeStreamRecordMapper mapper = mock(ChangeStreamRecordMapper.class);
+        MetricsEventPublisher metricsEventPublisher = mock(MetricsEventPublisher.class);
+
+        // Simulate 1 heartbeat event, then stream EOF (false)
+        when(changeStreamResultSet.next()).thenReturn(true, false);
+        when(changeStreamDao.streamQuery(any(), any(), any(), anyLong())).thenReturn(changeStreamResultSet);
+
+        HeartbeatEvent heartbeatEvent = new HeartbeatEvent(Timestamp.now(), mock(StreamEventMetadata.class));
+        when(mapper.toChangeStreamEvents(any(), any(), any())).thenReturn(List.of(heartbeatEvent));
+
+        SpannerChangeStreamService spannerChangeStreamService = new SpannerChangeStreamService("TaskUid", changeStreamDao,
+                mapper, Duration.ofMillis(1000), metricsEventPublisher);
+
+        // Partition with null endTimestamp (continuous CDC partition query)
+        HashSet<String> parentTokens = new HashSet<>();
+        Timestamp startTimestamp = Timestamp.ofTimeMicroseconds(1L);
+        Partition partition = new Partition("token", parentTokens, startTimestamp, null, "originParent");
+
+        ChangeStreamEventConsumer changeStreamEventConsumer = mock(ChangeStreamEventConsumer.class);
+        PartitionEventListener partitionEventListener = mock(PartitionEventListener.class);
+        doNothing().when(partitionEventListener).onRun(any());
+
+        ChangeStreamException thrown = assertThrows(ChangeStreamException.class, () -> {
+            spannerChangeStreamService.getEvents(partition, changeStreamEventConsumer, partitionEventListener);
+        });
+
+        assertTrue(thrown.getMessage().contains("without child partitions"));
+        verify(partitionEventListener, times(1)).onRun(partition);
+        verify(partitionEventListener, never()).onFinish(partition);
+        verify(changeStreamEventConsumer, never()).acceptChangeStreamEvent(any(FinishPartitionEvent.class));
+    }
+
+    @Test
+    void testBoundedStreamEndingBeforeEndTimestampThrowsException() throws Exception {
+        ChangeStreamDao changeStreamDao = mock(ChangeStreamDao.class);
+        ChangeStreamResultSet changeStreamResultSet = mock(ChangeStreamResultSet.class);
+        ChangeStreamRecordMapper mapper = mock(ChangeStreamRecordMapper.class);
+        MetricsEventPublisher metricsEventPublisher = mock(MetricsEventPublisher.class);
+
+        // Stream cut off at timestamp 50L, but partition endTimestamp is 100L
+        Timestamp eventTimestamp = Timestamp.ofTimeMicroseconds(50L);
+        HeartbeatEvent heartbeatEvent = new HeartbeatEvent(eventTimestamp, mock(StreamEventMetadata.class));
+        when(changeStreamResultSet.next()).thenReturn(true, false);
+        when(changeStreamDao.streamQuery(any(), any(), any(), anyLong())).thenReturn(changeStreamResultSet);
+        when(mapper.toChangeStreamEvents(any(), any(), any())).thenReturn(List.of(heartbeatEvent));
+
+        SpannerChangeStreamService spannerChangeStreamService = new SpannerChangeStreamService("TaskUid", changeStreamDao,
+                mapper, Duration.ofMillis(1000), metricsEventPublisher);
+
+        HashSet<String> parentTokens = new HashSet<>();
+        Timestamp startTimestamp = Timestamp.ofTimeMicroseconds(1L);
+        Timestamp endTimestamp = Timestamp.ofTimeMicroseconds(100L);
+        Partition partition = new Partition("token", parentTokens, startTimestamp, endTimestamp, "originParent");
+
+        ChangeStreamEventConsumer changeStreamEventConsumer = mock(ChangeStreamEventConsumer.class);
+        PartitionEventListener partitionEventListener = mock(PartitionEventListener.class);
+        doNothing().when(partitionEventListener).onRun(any());
+
+        ChangeStreamException thrown = assertThrows(ChangeStreamException.class, () -> {
+            spannerChangeStreamService.getEvents(partition, changeStreamEventConsumer, partitionEventListener);
+        });
+
+        assertTrue(thrown.getMessage().contains("reaching end timestamp"));
+        verify(partitionEventListener, times(1)).onRun(partition);
+        verify(partitionEventListener, never()).onFinish(partition);
+        verify(changeStreamEventConsumer, never()).acceptChangeStreamEvent(any(FinishPartitionEvent.class));
+    }
+
+    @Test
+    void testBoundedStreamReceivingChildPartitionsFinishesCleanly() throws Exception {
+        ChangeStreamDao changeStreamDao = mock(ChangeStreamDao.class);
+        ChangeStreamResultSet changeStreamResultSet = mock(ChangeStreamResultSet.class);
+        ChangeStreamRecordMapper mapper = mock(ChangeStreamRecordMapper.class);
+        MetricsEventPublisher metricsEventPublisher = mock(MetricsEventPublisher.class);
+
+        // Partition split before endTimestamp (at timestamp 50L)
+        Timestamp eventTimestamp = Timestamp.ofTimeMicroseconds(50L);
+        ChildPartitionsEvent childPartitionsEvent = mock(ChildPartitionsEvent.class);
+        when(childPartitionsEvent.getRecordTimestamp()).thenReturn(eventTimestamp);
+        when(childPartitionsEvent.getMetadata()).thenReturn(mock(StreamEventMetadata.class));
+
+        when(changeStreamResultSet.next()).thenReturn(true, false);
+        when(changeStreamDao.streamQuery(any(), any(), any(), anyLong())).thenReturn(changeStreamResultSet);
+        when(mapper.toChangeStreamEvents(any(), any(), any())).thenReturn(List.of(childPartitionsEvent));
+
+        SpannerChangeStreamService spannerChangeStreamService = new SpannerChangeStreamService("TaskUid", changeStreamDao,
+                mapper, Duration.ofMillis(1000), metricsEventPublisher);
+
+        HashSet<String> parentTokens = new HashSet<>();
+        Timestamp startTimestamp = Timestamp.ofTimeMicroseconds(1L);
+        Timestamp endTimestamp = Timestamp.ofTimeMicroseconds(100L);
+        Partition partition = new Partition("token", parentTokens, startTimestamp, endTimestamp, "originParent");
+
+        ChangeStreamEventConsumer changeStreamEventConsumer = mock(ChangeStreamEventConsumer.class);
+        PartitionEventListener partitionEventListener = mock(PartitionEventListener.class);
+        doNothing().when(partitionEventListener).onRun(any());
+        doNothing().when(partitionEventListener).onFinish(any());
+
+        spannerChangeStreamService.getEvents(partition, changeStreamEventConsumer, partitionEventListener);
+
+        verify(changeStreamEventConsumer).acceptChangeStreamEvent(childPartitionsEvent);
+        verify(changeStreamEventConsumer).acceptChangeStreamEvent(any(FinishPartitionEvent.class));
+        verify(partitionEventListener).onFinish(partition);
     }
 }

--- a/src/test/java/io/debezium/connector/spanner/db/stream/SpannerChangeStreamTest.java
+++ b/src/test/java/io/debezium/connector/spanner/db/stream/SpannerChangeStreamTest.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.connector.spanner.db.stream;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -195,5 +196,27 @@ class SpannerChangeStreamTest {
                 .until(() -> spannerChangeStream.submitPartition(partition));
 
         verify(metricsEventPublisher, times(2)).publishMetricEvent(any());
+    }
+
+    @Test
+    void testPartitionStreamFailureWithoutChildPartitions() {
+        SpannerChangeStreamService streamService = mock(SpannerChangeStreamService.class);
+        MetricsEventPublisher metricsEventPublisher = mock(MetricsEventPublisher.class);
+        DatabaseClientFactory databaseClientFactory = mock(DatabaseClientFactory.class);
+
+        HashSet<String> parentTokens = new HashSet<>();
+        Timestamp startTimestamp = Timestamp.ofTimeMicroseconds(1L);
+        Partition partition = new Partition("partitionToken", parentTokens, startTimestamp, null, "originParent");
+
+        SpannerChangeStream spannerChangeStream = new SpannerChangeStream(streamService, metricsEventPublisher, Duration.ofSeconds(60), 3, "taskuid",
+                databaseClientFactory);
+
+        ChangeStreamException ex = new ChangeStreamException("Partition partitionToken stream ended without child partitions.");
+        ChangeStreamException streamException = spannerChangeStream.getStreamException(partition, ex);
+
+        assertTrue(streamException instanceof ChangeStreamException);
+        assertFalse(streamException instanceof FailureChangeStreamException);
+        assertEquals(ex, streamException);
+        assertFalse(spannerChangeStream.onError(partition, ex));
     }
 }


### PR DESCRIPTION
Fixes debezium/dbz#2523

When a continuous change stream partition query terminates (resultSet.next() == false) without delivering a ChildPartitionsEvent, the connector was previously unconditionally marking the partition as FINISHED via FinishPartitionEvent. 

This change:
1. Validates that a continuous partition query received at least one ChildPartitionsEvent before completing.
2. Logs an explicit ERROR and throws a ChangeStreamException if child partition records were not delivered, allowing the partition to be re-marked as READY_FOR_STREAMING and to be retried again.
3. Adds unit tests in SpannerChangeStreamServiceTest and SpannerChangeStreamTest verifying exception throwing and error propagation.