### PR TITLE
debezium/dbz#2523 Fix possible infinite retry loop on bounded change stream partitions

### DIFF
--- a/src/main/java/io/debezium/connector/spanner/db/stream/SpannerChangeStreamService.java
+++ b/src/main/java/io/debezium/connector/spanner/db/stream/SpannerChangeStreamService.java
@@ -12,8 +12,6 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.cloud.Timestamp;
-
 import io.debezium.connector.spanner.db.dao.ChangeStreamDao;
 import io.debezium.connector.spanner.db.dao.ChangeStreamResultSet;
 import io.debezium.connector.spanner.db.mapper.ChangeStreamRecordMapper;
@@ -58,7 +56,6 @@ public class SpannerChangeStreamService {
         partitionEventListener.onRun(partition);
 
         LOGGER.info("Task: {}, Streaming {} from {} to {}", taskUid, token, partition.getStartTimestamp(), partition.getEndTimestamp());
-        Timestamp lastReceivedTimestamp = null;
         boolean receivedChildPartitions = false;
         try (ChangeStreamResultSet resultSet = changeStreamDao.streamQuery(token, partition.getStartTimestamp(),
                 partition.getEndTimestamp(), heartbeatMillis.toMillis())) {
@@ -75,11 +72,6 @@ public class SpannerChangeStreamService {
                 for (ChangeStreamEvent event : events) {
                     if (event instanceof ChildPartitionsEvent) {
                         receivedChildPartitions = true;
-                    }
-                    if (event.getRecordTimestamp() != null) {
-                        if (lastReceivedTimestamp == null || event.getRecordTimestamp().compareTo(lastReceivedTimestamp) > 0) {
-                            lastReceivedTimestamp = event.getRecordTimestamp();
-                        }
                     }
                 }
 

--- a/src/main/java/io/debezium/connector/spanner/db/stream/SpannerChangeStreamService.java
+++ b/src/main/java/io/debezium/connector/spanner/db/stream/SpannerChangeStreamService.java
@@ -108,18 +108,14 @@ public class SpannerChangeStreamService {
             return;
         }
 
-        boolean reachedEnd = receivedChildPartitions
-                || (partition.getEndTimestamp() != null
-                        && lastReceivedTimestamp != null
-                        && lastReceivedTimestamp.compareTo(partition.getEndTimestamp()) >= 0);
+        boolean reachedEnd = receivedChildPartitions || partition.getEndTimestamp() != null;
 
         if (!reachedEnd) {
             LOGGER.error(
-                    "Task: {}, Partition {} stream ended without delivering child partition records or reaching end timestamp {} (last received timestamp: {})! Retrying partition stream.",
-                    taskUid, token, partition.getEndTimestamp(), lastReceivedTimestamp);
+                    "Task: {}, Partition {} stream ended without delivering child partition records! Retrying partition stream.",
+                    taskUid, token);
             throw new ChangeStreamException(
-                    "Partition " + token + " stream ended without child partitions or reaching end timestamp "
-                            + partition.getEndTimestamp() + ". Retrying partition stream.");
+                    "Partition " + token + " stream ended without child partitions. Retrying partition stream.");
         }
 
         partitionEventListener.onFinish(partition);

--- a/src/test/java/io/debezium/connector/spanner/db/stream/SpannerChangeStreamServiceTest.java
+++ b/src/test/java/io/debezium/connector/spanner/db/stream/SpannerChangeStreamServiceTest.java
@@ -106,13 +106,13 @@ class SpannerChangeStreamServiceTest {
     }
 
     @Test
-    void testBoundedStreamEndingBeforeEndTimestampThrowsException() throws Exception {
+    void testBoundedStreamFinishesCleanlyWithoutChildPartitions() throws Exception {
         ChangeStreamDao changeStreamDao = mock(ChangeStreamDao.class);
         ChangeStreamResultSet changeStreamResultSet = mock(ChangeStreamResultSet.class);
         ChangeStreamRecordMapper mapper = mock(ChangeStreamRecordMapper.class);
         MetricsEventPublisher metricsEventPublisher = mock(MetricsEventPublisher.class);
 
-        // Stream cut off at timestamp 50L, but partition endTimestamp is 100L
+        // Bounded stream ending at timestamp 50L (< partition endTimestamp 100L)
         Timestamp eventTimestamp = Timestamp.ofTimeMicroseconds(50L);
         HeartbeatEvent heartbeatEvent = new HeartbeatEvent(eventTimestamp, mock(StreamEventMetadata.class));
         when(changeStreamResultSet.next()).thenReturn(true, false);
@@ -130,15 +130,13 @@ class SpannerChangeStreamServiceTest {
         ChangeStreamEventConsumer changeStreamEventConsumer = mock(ChangeStreamEventConsumer.class);
         PartitionEventListener partitionEventListener = mock(PartitionEventListener.class);
         doNothing().when(partitionEventListener).onRun(any());
+        doNothing().when(partitionEventListener).onFinish(any());
 
-        ChangeStreamException thrown = assertThrows(ChangeStreamException.class, () -> {
-            spannerChangeStreamService.getEvents(partition, changeStreamEventConsumer, partitionEventListener);
-        });
+        spannerChangeStreamService.getEvents(partition, changeStreamEventConsumer, partitionEventListener);
 
-        assertTrue(thrown.getMessage().contains("reaching end timestamp"));
-        verify(partitionEventListener, times(1)).onRun(partition);
-        verify(partitionEventListener, never()).onFinish(partition);
-        verify(changeStreamEventConsumer, never()).acceptChangeStreamEvent(any(FinishPartitionEvent.class));
+        verify(changeStreamEventConsumer).acceptChangeStreamEvent(heartbeatEvent);
+        verify(changeStreamEventConsumer).acceptChangeStreamEvent(any(FinishPartitionEvent.class));
+        verify(partitionEventListener).onFinish(partition);
     }
 
     @Test


### PR DESCRIPTION
When a bounded change stream partition query (endTimestamp != null) completes (resultSet.next() == false), the backend query has scanned all rows up to endTimestamp.

Requiring lastReceivedTimestamp >= endTimestamp caused bounded queries ending with a DataChangeRecord at T < endTimestamp to throw ChangeStreamException and retry from T indefinitely because start_timestamp is inclusive.

This fix:
1. Updates reachedEnd in SpannerChangeStreamService to allow bounded queries (partition.getEndTimestamp() != null) to complete normally on EOF without requiring lastReceivedTimestamp >= endTimestamp.
2. Preserves the validation that unbounded queries (endTimestamp == null) must receive ChildPartitionsEvent before completing, continuing to protect against silent stream dropouts.
3. Updates unit tests in SpannerChangeStreamServiceTest.